### PR TITLE
LIME-172 - Re-introducing pepEnabled feature toggle default

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ConfigurationService.java
@@ -1,6 +1,8 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.parameters.ParamProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 
@@ -9,6 +11,8 @@ import java.util.Objects;
 import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 public class ConfigurationService {
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     static class KeyStoreParams {
         private String keyStore;
@@ -68,7 +72,15 @@ public class ConfigurationService {
 
         // *****************************Feature Toggles*******************************
 
-        this.pepEnabled = paramProvider.get(getParameterName("pepEnabled"));
+        String pepEnabledFlag;
+        try {
+            // pepEnabled flag will need to be manually added as a parameter in AWS
+            pepEnabledFlag = paramProvider.get(getParameterName("pepEnabled"));
+        } catch (Exception e) {
+            LOGGER.info("Failed to get pepEnabled paramater in store, defaulting to false");
+            pepEnabledFlag = "false";
+        }
+        this.pepEnabled = pepEnabledFlag;
 
         // *********************************Secrets***********************************
 


### PR DESCRIPTION
### What changed

Re-introduced fail safe for pepEnabled feature toggle so that for instances where the parameter is not set in AWS store, nullPointers are avoided.

### Why did it change

For making it easy to turn pep checks on and off in fraud (removing the parameter in the parameter is all that is required)

### Additional notes

@tal-nagra I am aware that you have added the parameter setting to the template so (in theory) this parameter will always be set, however I feel this fail safe is better practice for instances where out of hours workers have to turn off this parameter, by being able to do this in the store they would not be relying on an approval for a small template change that could take some time
