### PR TITLE
OJ-1422: add release flag for contains unique

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib              : "1.4.5"
+		cri_common_lib              : "1.5.2"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -129,6 +129,14 @@ Mappings:
       integration: "true"
       production: "true"
 
+  VcContainsUniqueIdMapping:
+    Environment:
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "false"
+      production: "false"
+
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
     Environment:
@@ -476,6 +484,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             Effect: Allow
             Action:
@@ -593,6 +602,14 @@ Resources:
       Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
       Type: String
       Description: Expiry date release toggle
+
+  ReleaseFlagsVcContainsUniqueIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
+      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Type: String
+      Description: Verifiable Credential Contains UniqueId Mapping
 
   ParameterFraudItemTableName:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
## Proposed changes

Use release-flag for `vc-contains-unique-id` for `di-ipv-cri-fraud-api` implemented by https://github.com/alphagov/di-ipv-cri-lib/pull/244

### What changed

Added release_flag for `vc-contains-unique-id` this can be activated by setting the environment flag to true in the template file

```
  VcContainsUniqueIdMapping:
    Environment:
      dev: "false"
      build: "false"
      staging: "false"
      integration: "false"
      production: "false"
``` 

### Why did it change

see: https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-optionIn order to be able to distinguish one Verifiable Credential (VC) from another VC it will be necessary for VCs to be able to be uniquely identifiable

### Issue tracking
- [jti in context of a VC](https://github.com/alphagov/digital-identity-architecture/blob/7c90be0db85a3a3093c766d845d5f278a3d86e16/rfc/0045-claimed-identity-cri.md?plain=1#L217)
- [ADR 0079 Unique identifiers for verifiable credentials](https://github.com/alphagov/digital-identity-architecture/blob/7c90be0db85a3a3093c766d845d5f278a3d86e16/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-option)

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

### Other considerations:
This PR is dependent on version 1.5.2 of the below
- see https://github.com/alphagov/di-ipv-cri-lib/pull/244

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ