### PR TITLE
LIME-862: Removing the 4XX alarm from the Fraud CRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ See onboarding guide for instructions on how to setup the following command line
 
 Any time you wish to deploy, run:
 
-`gds aws di-ipv-cri-dev -- ./deploy.sh my-fraud-api-stack-name`
+`aws-vault exec fraud-dev -- ./deploy.sh my-fraud-api-stack-name`
 
 ### Delete stack from dev account
 > The stack name *must* be unique to you and created by you in the deploy stage above.
-> Type `y`es when prompted to delete the stack and the folders in S3 bucket
+> Type `yes` when prompted to delete the stack and the folders in S3 bucket
 
 The command to run is:
 
-`gds aws di-ipv-cri-dev -- sam delete --config-env dev --stack-name <unique-stack-name>`
+`aws-vault exec fraud-dev -- sam delete --config-env dev --stack-name <unique-stack-name>`

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -18,7 +18,7 @@ Feature: Fraud CRI
     When I view the Beta banner
     When the beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
     And I select Reject analytics cookies button
-    Then I see the Reject Analysis sentence You’ve rejected additional cookies. You can change your cookie settings at any time.
+    Then I see the Reject Analysis sentence You've rejected additional cookies. You can change your cookie settings at any time.
     Then  I select the link change your cookie settings
     Then I check the page to change cookie preferences opens
     And The test is complete and I close the driver

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -754,50 +754,6 @@ Resources:
             Period: 300
             Stat: Sum
 
-  FraudAPIGW4XXErrors:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmDescription: !Sub Fraud ${Environment} API Gateway 4XX errors
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlarmTopicFraud
-      OKActions:
-        - !Ref AlarmTopicFraud
-      InsufficientDataActions: []
-      Dimensions: []
-      DatapointsToAlarm: 3
-      EvaluationPeriods: 3
-      Threshold: 2
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      Metrics:
-        - Id: e1
-          Label: Expression1
-          ReturnData: true
-          Expression: SUM(METRICS())
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 4XXError
-              Dimensions:
-                - Name: ApiName
-                  Value: !Sub "${AWS::StackName}-PublicFraudApi"
-            Period: 300
-            Stat: Sum
-        - Id: m2
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 4XXError
-              Dimensions:
-                - Name: ApiName
-                  Value: !Sub "${AWS::StackName}-PrivateFraudApi"
-            Period: 300
-            Stat: Sum
-
   FraudPepCheckFail:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Removed 4XX alarm from template

### Why did it change

So that we are no longer running P1 alerts for 400's in production
