### PR TITLE
LIME-889 Switch FraudAPI HTTPClient to Apache 4.5 HttpClient

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
@@ -85,6 +85,15 @@ public class Driver {
                     break;
             }
         }
+
+        try {
+            // Avoid increasing this too much as Driver.get() is called many times,
+            // A correct fix is to check the document state where needed.
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         return driverPool.get();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id "java"
 	id "org.sonarqube"
 	id "com.diffplug.spotless"
+	id "io.freefair.lombok" version "6.6.3"
 }
 
 defaultTasks 'clean', 'spotlessApply', 'build'
@@ -9,7 +10,7 @@ defaultTasks 'clean', 'spotlessApply', 'build'
 ext {
 	dependencyVersions = [
 		jackson_version             : "2.13.1",
-		aws_sdk_version             : "1.12.153",
+		aws_sdk_version             : "2.21.9",
 		aws_lambda_events_version   : "3.11.0",
 		aws_powertools_version      : "1.12.2",
 		nimbusds_oauth_version      : "9.25",
@@ -17,7 +18,8 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib              : "1.4.5"
+		cri_common_lib              : "1.4.5",
+		lombok_version              : "1.18.22"
 	]
 }
 
@@ -28,6 +30,7 @@ repositories {
 }
 
 subprojects {
+	apply plugin: 'io.freefair.lombok'
 
 	java {
 		sourceCompatibility = JavaVersion.VERSION_11
@@ -43,6 +46,7 @@ subprojects {
 
 	configurations {
 		aws
+		aws_apache_http_client
 		dynamodb
 		jackson
 		lambda
@@ -58,18 +62,15 @@ subprojects {
 		mockito
 		logging_runtime
 		cri_common_lib
-	}
-
-	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
-	// we need to add the apache-client to the dependencies exclusion to not get a mismatch
-	configurations.all {
-		exclude group:"software.amazon.awssdk", module: "apache-client"
+		lombok
 	}
 
 	dependencies {
 		cri_common_lib "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib}"
 
-		aws platform('software.amazon.awssdk:bom:2.17.191')
+		aws platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}")
+
+		aws_apache_http_client "software.amazon.awssdk:apache-client:${dependencyVersions.aws_sdk_version}"
 
 		dynamodb "software.amazon.awssdk:dynamodb",
 				"software.amazon.awssdk:dynamodb-enhanced"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx1024m
+org.gradle.parallel=true

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -54,29 +54,12 @@ Conditions:
   EnforceCodeSigning: !Equals
     - !Ref CodeSigningEnabled
     - true
-  CreateDevResources: !Equals
-    - !Ref Environment
-    - dev
-  IsStubEnvironment: !Or
-    - !Equals [ !Ref Environment, dev]
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-  IsProdLikeEnvironment: !Or
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-    - !Equals [ !Ref Environment, production ]
   IsProdEnvironment: !Equals
     - !Ref Environment
     - production
   IsPerformance: !Or
     - !Equals [ !Ref Environment, build ]
     - !Equals [ !Ref Environment, production ]
-  IsDevEnvironment: !Equals
-    - !Ref Environment
-    - dev
-  IsNotDevEnvironment: !Not
-    - Condition: IsDevEnvironment
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:

--- a/lambdas/fraudcheck/build.gradle
+++ b/lambdas/fraudcheck/build.gradle
@@ -1,13 +1,15 @@
 plugins {
 	id "java"
 	id "jacoco"
-	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
+	id "io.freefair.aspectj.post-compile-weaving" version "6.6.3"
+	id 'java-test-fixtures'
 }
 
 dependencies {
 	implementation project(":lib"),
 			configurations.cri_common_lib,
 			configurations.aws,
+			configurations.aws_apache_http_client,
 			configurations.lambda,
 			configurations.nimbus,
 			configurations.dynamodb,
@@ -16,7 +18,9 @@ dependencies {
 
 	aspect configurations.powertools
 
-	testImplementation configurations.tests
+	testImplementation configurations.tests, testFixtures(this.project)
+
+	testFixturesImplementation configurations.aws_apache_http_client
 
 	testRuntimeOnly configurations.test_runtime
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/FraudCheckResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/FraudCheckResult.java
@@ -1,4 +1,4 @@
-package uk.gov.di.ipv.cri.fraud.api.domain;
+package uk.gov.di.ipv.cri.fraud.api.domain.check;
 
 public class FraudCheckResult {
     private boolean executedSuccessfully;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/PepCheckResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/PepCheckResult.java
@@ -1,0 +1,44 @@
+package uk.gov.di.ipv.cri.fraud.api.domain.check;
+
+public class PepCheckResult {
+    private boolean executedSuccessfully;
+    private String[] thirdPartyFraudCodes;
+    private String errorMessage;
+    private String transactionId;
+
+    public PepCheckResult() {
+        this.thirdPartyFraudCodes = new String[] {};
+    }
+
+    public boolean isExecutedSuccessfully() {
+        return executedSuccessfully;
+    }
+
+    public void setExecutedSuccessfully(boolean executedSuccessfully) {
+        this.executedSuccessfully = executedSuccessfully;
+    }
+
+    public String[] getThirdPartyFraudCodes() {
+        return thirdPartyFraudCodes;
+    }
+
+    public void setThirdPartyFraudCodes(String[] thirdPartyFraudCodes) {
+        this.thirdPartyFraudCodes = thirdPartyFraudCodes;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
@@ -146,7 +146,8 @@ public class ThirdPartyFraudGateway {
         final HTTPReply httpReply;
         LOGGER.info("Submitting {} request", REQUEST_NAME);
         try {
-            httpReply = httpRetryer.sendHTTPRequestRetryIfAllowed(
+            httpReply =
+                    httpRetryer.sendHTTPRequestRetryIfAllowed(
                             postRequest, fraudHttpRetryStatusConfig, REQUEST_NAME);
             eventProbe.counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
             // throws OAuthErrorResponseException on error
@@ -166,10 +167,9 @@ public class ThirdPartyFraudGateway {
 
     private FraudCheckResult fraudCheckResponseHandler(HTTPReply httpReply)
             throws OAuthErrorResponseException {
-        int statusCode = httpReply.statusCode;
-        LOGGER.info("{} response code {}", REQUEST_NAME, statusCode);
 
-        if (statusCode == 200) {
+        if (null != httpReply && httpReply.getStatusCode() == 200) {
+            LOGGER.info("{} response code {}", REQUEST_NAME, httpReply.getStatusCode());
 
             eventProbe.counterMetric(FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
 
@@ -197,6 +197,10 @@ public class ThirdPartyFraudGateway {
             return responseMapper.mapFraudResponse(fraudCheckResponse);
 
         } else {
+            if (null != httpReply) {
+                LOGGER.info("{} response code {}", REQUEST_NAME, httpReply.getStatusCode());
+            }
+
             eventProbe.counterMetric(
                     FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -20,7 +19,6 @@ import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
 import uk.gov.di.ipv.cri.fraud.api.util.HTTPReply;
-import uk.gov.di.ipv.cri.fraud.api.util.HTTPReplyHelper;
 import uk.gov.di.ipv.cri.fraud.library.config.HttpRequestConfig;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
@@ -147,12 +145,11 @@ public class ThirdPartyFraudGateway {
 
         final HTTPReply httpReply;
         LOGGER.info("Submitting {} request", REQUEST_NAME);
-        try (CloseableHttpResponse response =
-                httpRetryer.sendHTTPRequestRetryIfAllowed(
-                        postRequest, fraudHttpRetryStatusConfig)) {
+        try {
+            httpReply = httpRetryer.sendHTTPRequestRetryIfAllowed(
+                            postRequest, fraudHttpRetryStatusConfig, REQUEST_NAME);
             eventProbe.counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
             // throws OAuthErrorResponseException on error
-            httpReply = HTTPReplyHelper.retrieveResponse(response, REQUEST_NAME);
         } catch (IOException e) {
             LOGGER.error("IOException executing {} http request {}", REQUEST_NAME, e.getMessage());
             eventProbe.counterMetric(FRAUD_REQUEST_SEND_ERROR.withEndpointPrefix());

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
@@ -13,12 +13,12 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.IdentityVerificationRequest;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
-import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckHttpRetryStatusConfig;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
+import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.util.HTTPReply;
 import uk.gov.di.ipv.cri.fraud.api.util.HTTPReplyHelper;
 import uk.gov.di.ipv.cri.fraud.library.config.HttpRequestConfig;
@@ -31,23 +31,22 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.ERROR_FRAUD_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE;
-import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.ERROR_SENDING_FRAUD_CHECK_REQUEST;
-import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.FAILED_TO_CREATE_API_REQUEST_FOR_FRAUD_CHECK;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_REQUEST_CREATED;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_REQUEST_SEND_ERROR;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_REQUEST_SEND_OK;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_INVALID;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_VALID;
+import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE;
+import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.FAILED_TO_CREATE_API_REQUEST_FOR_PEP_CHECK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_CREATED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_SEND_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_INVALID;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_VALID;
 
-public class ThirdPartyFraudGateway {
+public class ThirdPartyPepGateway {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final String REQUEST_NAME = "Fraud Check";
+    private static final String REQUEST_NAME = "Pep Check";
 
     private final IdentityVerificationRequestMapper requestMapper;
     private final IdentityVerificationResponseMapper responseMapper;
@@ -60,16 +59,16 @@ public class ThirdPartyFraudGateway {
     private final Clock clock;
 
     // HTTP
-    private final HttpRetryStatusConfig fraudHttpRetryStatusConfig;
+    private final HttpRetryStatusConfig pepHttpRetryStatusConfig;
     private final HttpRetryer httpRetryer;
 
     // POOL_REQ + CONN_EST + HTTP_RESP = overall max timeout
     private static final int POOL_REQUEST_TIMEOUT_MS = 5000;
     private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 5000;
-    private static final int FRAUD_HTTP_RESPONSE_TIMEOUT_MS = 5000;
-    private final RequestConfig fraudCheckRequestConfig;
+    private static final int PEP_HTTP_RESPONSE_TIMEOUT_MS = 10000;
+    private final RequestConfig pepCheckRequestConfig;
 
-    public ThirdPartyFraudGateway(
+    public ThirdPartyPepGateway(
             HttpRetryer httpRetryer,
             IdentityVerificationRequestMapper requestMapper,
             IdentityVerificationResponseMapper responseMapper,
@@ -95,13 +94,13 @@ public class ThirdPartyFraudGateway {
         this.eventProbe = eventProbe;
         this.clock = Clock.systemUTC();
 
-        this.fraudHttpRetryStatusConfig = new FraudCheckHttpRetryStatusConfig();
+        this.pepHttpRetryStatusConfig = new PepCheckHttpRetryStatusConfig();
 
-        this.fraudCheckRequestConfig =
+        this.pepCheckRequestConfig =
                 HttpRequestConfig.getCustomRequestConfig(
                         POOL_REQUEST_TIMEOUT_MS,
                         CONNECTION_ESTABLISHMENT_TIMEOUT_MS,
-                        FRAUD_HTTP_RESPONSE_TIMEOUT_MS);
+                        PEP_HTTP_RESPONSE_TIMEOUT_MS);
     }
 
     private HttpPost httpRequestBuilder(String requestBody) {
@@ -114,10 +113,10 @@ public class ThirdPartyFraudGateway {
         return request;
     }
 
-    public FraudCheckResult performFraudCheck(PersonIdentity personIdentity)
+    public PepCheckResult performPepCheck(PersonIdentity personIdentity)
             throws OAuthErrorResponseException {
         LOGGER.info("Mapping person to {} request", REQUEST_NAME);
-        IdentityVerificationRequest apiRequest = requestMapper.mapPersonIdentity(personIdentity);
+        PEPRequest apiRequest = requestMapper.mapPEPPersonIdentity(personIdentity);
 
         String requestBody = null;
         try {
@@ -127,89 +126,85 @@ public class ThirdPartyFraudGateway {
             // PII in variables
             LOGGER.error(
                     "JsonProcessingException {}",
-                    FAILED_TO_CREATE_API_REQUEST_FOR_FRAUD_CHECK.getMessage());
+                    FAILED_TO_CREATE_API_REQUEST_FOR_PEP_CHECK.getMessage());
             LOGGER.debug(e.getMessage());
 
             throw new OAuthErrorResponseException(
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_CREATE_API_REQUEST_FOR_FRAUD_CHECK);
+                    FAILED_TO_CREATE_API_REQUEST_FOR_PEP_CHECK);
         }
 
         LOGGER.debug("{} Request {}", REQUEST_NAME, requestBody);
         HttpPost postRequest = httpRequestBuilder(requestBody);
 
         // Enforce connection timeout values
-        postRequest.setConfig(fraudCheckRequestConfig);
+        postRequest.setConfig(pepCheckRequestConfig);
 
-        eventProbe.counterMetric(FRAUD_REQUEST_CREATED.withEndpointPrefix());
+        eventProbe.counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
 
         var startCheck = clock.instant();
 
         final HTTPReply httpReply;
-        LOGGER.info("Submitting {} request", REQUEST_NAME);
+        LOGGER.info("Submitting {} request...", REQUEST_NAME);
         try (CloseableHttpResponse response =
-                httpRetryer.sendHTTPRequestRetryIfAllowed(
-                        postRequest, fraudHttpRetryStatusConfig)) {
-            eventProbe.counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
+                httpRetryer.sendHTTPRequestRetryIfAllowed(postRequest, pepHttpRetryStatusConfig)) {
+            eventProbe.counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
             // throws OAuthErrorResponseException on error
             httpReply = HTTPReplyHelper.retrieveResponse(response, REQUEST_NAME);
         } catch (IOException e) {
             LOGGER.error("IOException executing {} http request {}", REQUEST_NAME, e.getMessage());
-            eventProbe.counterMetric(FRAUD_REQUEST_SEND_ERROR.withEndpointPrefix());
+            eventProbe.counterMetric(PEP_REQUEST_SEND_ERROR.withEndpointPrefix());
             throw new OAuthErrorResponseException(
-                    HttpStatusCode.INTERNAL_SERVER_ERROR, ERROR_SENDING_FRAUD_CHECK_REQUEST);
+                    HttpStatusCode.INTERNAL_SERVER_ERROR,
+                    ErrorResponse.ERROR_SENDING_PEP_CHECK_REQUEST);
         }
 
         long latency = Duration.between(startCheck, clock.instant()).toMillis();
-        eventProbe.counterMetric(THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS, latency);
+        eventProbe.counterMetric(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS, latency);
         LOGGER.info("{} latency {}", REQUEST_NAME, latency);
 
-        return fraudCheckResponseHandler(httpReply);
+        return pepCheckResponseHandler(httpReply);
     }
 
-    private FraudCheckResult fraudCheckResponseHandler(HTTPReply httpReply)
+    private PepCheckResult pepCheckResponseHandler(HTTPReply httpReply)
             throws OAuthErrorResponseException {
         int statusCode = httpReply.statusCode;
         LOGGER.info("{} response code {}", REQUEST_NAME, statusCode);
 
         if (statusCode == 200) {
 
-            eventProbe.counterMetric(FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+            eventProbe.counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
 
             String responseBody = httpReply.responseBody;
             LOGGER.debug("{} response {}", REQUEST_NAME, responseBody);
-            IdentityVerificationResponse fraudCheckResponse;
+            PEPResponse pepResponse;
 
             try {
-                fraudCheckResponse =
-                        objectMapper.readValue(responseBody, IdentityVerificationResponse.class);
+                pepResponse = objectMapper.readValue(responseBody, PEPResponse.class);
             } catch (JsonProcessingException e) {
                 LOGGER.error("JsonProcessingException mapping {} response", REQUEST_NAME);
                 LOGGER.debug(e.getMessage());
 
-                eventProbe.counterMetric(FRAUD_RESPONSE_TYPE_INVALID.withEndpointPrefix());
+                eventProbe.counterMetric(PEP_RESPONSE_TYPE_INVALID.withEndpointPrefix());
 
                 throw new OAuthErrorResponseException(
                         HttpStatusCode.INTERNAL_SERVER_ERROR,
-                        ErrorResponse.FAILED_TO_MAP_FRAUD_CHECK_RESPONSE_BODY);
+                        ErrorResponse.FAILED_TO_MAP_PEP_CHECK_RESPONSE_BODY);
             }
 
-            // Note this refers to the API response being able to be object mapped correctly
-            eventProbe.counterMetric(FRAUD_RESPONSE_TYPE_VALID.withEndpointPrefix());
+            eventProbe.counterMetric(PEP_RESPONSE_TYPE_VALID.withEndpointPrefix());
 
-            return responseMapper.mapFraudResponse(fraudCheckResponse);
-
+            return responseMapper.mapPEPResponse(pepResponse);
         } else {
-            eventProbe.counterMetric(
-                    FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
+            eventProbe.counterMetric(PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
 
-            FraudCheckResult fraudCheckResult = new FraudCheckResult();
-            fraudCheckResult.setExecutedSuccessfully(false);
+            PepCheckResult pepCheckResult = new PepCheckResult();
+            pepCheckResult.setExecutedSuccessfully(false);
 
-            fraudCheckResult.setErrorMessage(
-                    ERROR_FRAUD_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE.getMessage());
+            pepCheckResult.setErrorMessage(
+                    ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE.getMessage());
 
-            return fraudCheckResult;
+            return pepCheckResult;
         }
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -20,7 +19,6 @@ import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
 import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.util.HTTPReply;
-import uk.gov.di.ipv.cri.fraud.api.util.HTTPReplyHelper;
 import uk.gov.di.ipv.cri.fraud.library.config.HttpRequestConfig;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
@@ -146,11 +144,11 @@ public class ThirdPartyPepGateway {
 
         final HTTPReply httpReply;
         LOGGER.info("Submitting {} request...", REQUEST_NAME);
-        try (CloseableHttpResponse response =
-                httpRetryer.sendHTTPRequestRetryIfAllowed(postRequest, pepHttpRetryStatusConfig)) {
+        try {
+            httpReply = httpRetryer.sendHTTPRequestRetryIfAllowed(
+                            postRequest, pepHttpRetryStatusConfig, REQUEST_NAME);
             eventProbe.counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
             // throws OAuthErrorResponseException on error
-            httpReply = HTTPReplyHelper.retrieveResponse(response, REQUEST_NAME);
         } catch (IOException e) {
             LOGGER.error("IOException executing {} http request {}", REQUEST_NAME, e.getMessage());
             eventProbe.counterMetric(PEP_REQUEST_SEND_ERROR.withEndpointPrefix());

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
@@ -145,7 +145,8 @@ public class ThirdPartyPepGateway {
         final HTTPReply httpReply;
         LOGGER.info("Submitting {} request...", REQUEST_NAME);
         try {
-            httpReply = httpRetryer.sendHTTPRequestRetryIfAllowed(
+            httpReply =
+                    httpRetryer.sendHTTPRequestRetryIfAllowed(
                             postRequest, pepHttpRetryStatusConfig, REQUEST_NAME);
             eventProbe.counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
             // throws OAuthErrorResponseException on error
@@ -166,10 +167,9 @@ public class ThirdPartyPepGateway {
 
     private PepCheckResult pepCheckResponseHandler(HTTPReply httpReply)
             throws OAuthErrorResponseException {
-        int statusCode = httpReply.statusCode;
-        LOGGER.info("{} response code {}", REQUEST_NAME, statusCode);
 
-        if (statusCode == 200) {
+        if (null != httpReply && httpReply.getStatusCode() == 200) {
+            LOGGER.info("{} response code {}", REQUEST_NAME, httpReply.getStatusCode());
 
             eventProbe.counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
 
@@ -194,6 +194,9 @@ public class ThirdPartyPepGateway {
 
             return responseMapper.mapPEPResponse(pepResponse);
         } else {
+            if (null != httpReply) {
+                LOGGER.info("{} response code {}", REQUEST_NAME, httpReply.getStatusCode());
+            }
             eventProbe.counterMetric(PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
 
             PepCheckResult pepCheckResult = new PepCheckResult();

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -39,7 +39,6 @@ import java.util.UUID;
 
 import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.LAMBDA_IDENTITY_CHECK_COMPLETED_ERROR;
 import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.LAMBDA_IDENTITY_CHECK_COMPLETED_OK;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.TODO_REMOVE_BK_COMPAT_M1;
 
 public class FraudHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -143,8 +142,6 @@ public class FraudHandler
             }
             LOGGER.info("Identity verified.");
 
-            eventProbe.counterMetric(TODO_REMOVE_BK_COMPAT_M1);
-
             LOGGER.info("Generating authorization code...");
             sessionService.createAuthorizationCode(sessionItem);
 
@@ -175,7 +172,6 @@ public class FraudHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatusCode.OK, result);
         } catch (Exception e) {
             LOGGER.warn("Exception while handling lambda {}", context.getFunctionName());
-            eventProbe.counterMetric(TODO_REMOVE_BK_COMPAT_M1, 0d);
             eventProbe.log(Level.ERROR, e).counterMetric(LAMBDA_IDENTITY_CHECK_COMPLETED_ERROR);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.GENERIC_SERVER_ERROR);

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ContraIndicatorRemoteMapper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ContraIndicatorRemoteMapper.java
@@ -3,7 +3,12 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ContraIndicatorRemoteMapper implements ContraindicationMapper {
@@ -12,11 +17,8 @@ public class ContraIndicatorRemoteMapper implements ContraindicationMapper {
     private static final String CIMAP = "CIMap";
 
     private final Map<String, String> uCodeCIMap;
-    private ConfigurationService configurationService;
 
     public ContraIndicatorRemoteMapper(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-
         final String contraindicatorMappingString =
                 System.getenv().get(CIMAP) == null
                         ? configurationService.getContraindicationMappings()

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckHttpRetryStatusConfig.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckHttpRetryStatusConfig.java
@@ -1,0 +1,64 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import java.util.List;
+
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_HTTP_RETRYER_REQUEST_SEND_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_HTTP_RETRYER_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_HTTP_RETRYER_REQUEST_SEND_RETRY;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_HTTP_RETRYER_SEND_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_HTTP_RETRYER_SEND_MAX_RETRIES;
+
+public class FraudCheckHttpRetryStatusConfig implements HttpRetryStatusConfig {
+
+    private final List<Integer> neverRetryCodes = List.of(200);
+
+    private final List<Integer> retryCodes = List.of(429);
+
+    private final List<Integer> successStatusCodes = List.of(200);
+
+    @Override
+    public boolean shouldHttpClientRetry(int statusCode) {
+
+        if (neverRetryCodes.contains(statusCode)) {
+            return false;
+        }
+
+        // Retry all 500 errors
+        if ((statusCode >= 500) && (statusCode <= 599)) {
+            return true;
+        }
+
+        // Only status codes we will retry on
+        return retryCodes.contains(statusCode);
+    }
+
+    @Override
+    public boolean isSuccessStatusCode(int statusCode) {
+        return successStatusCodes.contains(statusCode);
+    }
+
+    @Override
+    public String httpRetryerSendOkMetric() {
+        return FRAUD_HTTP_RETRYER_REQUEST_SEND_OK.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerSendFailMetric(Exception e) {
+        return FRAUD_HTTP_RETRYER_REQUEST_SEND_FAIL.withEndpointPrefixAndExceptionName(e);
+    }
+
+    @Override
+    public String httpRetryerSendErrorMetric() {
+        return FRAUD_HTTP_RETRYER_SEND_ERROR.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerSendRetryMetric() {
+        return FRAUD_HTTP_RETRYER_REQUEST_SEND_RETRY.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerMaxRetriesMetric() {
+        return FRAUD_HTTP_RETRYER_SEND_MAX_RETRIES.withEndpointPrefix();
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryStatusConfig.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryStatusConfig.java
@@ -1,0 +1,21 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+public interface HttpRetryStatusConfig {
+    // Call back to allow configuring the status codes to retry per api/endpoint
+    boolean shouldHttpClientRetry(int statusCode);
+
+    // Typically 200, is the only success code,
+    // API's may have others depending on implementation
+    boolean isSuccessStatusCode(int statusCode);
+
+    // Call backs to allow http retry metrics to be captured per api/endpoint
+    String httpRetryerSendOkMetric();
+
+    String httpRetryerSendFailMetric(Exception e);
+
+    String httpRetryerSendErrorMetric();
+
+    String httpRetryerSendRetryMetric();
+
+    String httpRetryerMaxRetriesMetric();
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryer.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryer.java
@@ -1,0 +1,153 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.fraud.api.util.SleepHelper;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+public class HttpRetryer {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final long HTTP_RETRY_WAIT_TIME_LIMIT_MS = 12800L;
+
+    private final SleepHelper sleepHelper;
+    private final CloseableHttpClient httpClient;
+
+    private final int maxRetries;
+
+    private final EventProbe eventProbe;
+
+    public HttpRetryer(CloseableHttpClient httpClient, EventProbe eventProbe, int maxRetries) {
+        this.sleepHelper = new SleepHelper(HTTP_RETRY_WAIT_TIME_LIMIT_MS);
+        this.httpClient = httpClient;
+        this.eventProbe = eventProbe;
+        this.maxRetries = maxRetries;
+
+        LOGGER.info("Max retries configured as {}", maxRetries);
+    }
+
+    public CloseableHttpResponse sendHTTPRequestRetryIfAllowed(
+            HttpUriRequest request, HttpRetryStatusConfig httpRetryStatusConfig)
+            throws IOException {
+
+        CloseableHttpResponse httpResponse = null;
+
+        // 0 is initial request, > 0 are retries
+        int tryCount = 0;
+        boolean retry = false;
+
+        do {
+            if (retry) {
+                eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerSendRetryMetric());
+
+                freeHttpConnectionBackToPool(httpResponse);
+            }
+
+            // Wait before sending request (0ms for first try)
+            sleepHelper.busyWaitWithExponentialBackOff(tryCount);
+
+            try {
+                httpResponse = httpClient.execute(request);
+
+                int statusCode = httpResponse.getStatusLine().getStatusCode();
+
+                retry = httpRetryStatusConfig.shouldHttpClientRetry(statusCode);
+
+                if (retry) {
+                    LOGGER.warn("shouldHttpClientRetry statusCode - {}", statusCode);
+                }
+
+                LOGGER.info(
+                        "HTTPRequestRetry - totalRequests {}, retries {}, retryNeeded {}, statusCode {}",
+                        tryCount + 1,
+                        tryCount,
+                        retry,
+                        statusCode);
+
+            } catch (IOException e) {
+                // Logic is "Not any of"
+                if (!((e instanceof ConnectTimeoutException)
+                        || (e instanceof SocketTimeoutException))) {
+                    // Only above exceptions retried, All other IOExceptions are not
+                    LOGGER.warn(
+                            "Failure when executing http request - {} reason {}",
+                            e.getClass().getCanonicalName(),
+                            e.getMessage());
+                    eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerSendFailMetric(e));
+
+                    freeHttpConnectionBackToPool(httpResponse);
+
+                    throw e;
+                }
+
+                // For retries (tryCount>0) we want to rethrow only the last Exception
+                if (tryCount < maxRetries) {
+
+                    LOGGER.info(
+                            "HTTPRequestRetry {} - totalRequests {}, retries {}, retrying {}",
+                            e.getMessage(),
+                            tryCount + 1,
+                            tryCount,
+                            true);
+
+                    retry = true;
+                } else {
+
+                    LOGGER.info(
+                            "HTTPRequestRetry {} - totalRequests {}, retries {}, retrying {}",
+                            e.getMessage(),
+                            tryCount + 1,
+                            tryCount,
+                            false);
+
+                    LOGGER.warn(
+                            "Failure when executing http request - {} reason {}",
+                            e.getClass().getCanonicalName(),
+                            e.getMessage());
+                    eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerSendFailMetric(e));
+
+                    freeHttpConnectionBackToPool(httpResponse);
+
+                    throw e;
+                }
+            }
+        } while (retry && (tryCount++ < maxRetries));
+
+        int lastStatusCode = httpResponse.getStatusLine().getStatusCode();
+        LOGGER.info("HTTPRequestRetry Exited lastStatusCode {}", lastStatusCode);
+
+        if (httpRetryStatusConfig.isSuccessStatusCode(lastStatusCode)) {
+            eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerSendOkMetric());
+        } else if (tryCount < maxRetries) {
+            // Reachable when the remote api responds initially with a retryable status code, then
+            // during a retry with a non-retryable status code.
+            eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerSendErrorMetric());
+        } else {
+            eventProbe.counterMetric(httpRetryStatusConfig.httpRetryerMaxRetriesMetric());
+        }
+
+        return httpResponse;
+    }
+
+    /***
+     * This avoids using all the limited number of http connection pool
+     * resources, by closing previous responses when errors occur.
+     * @param httpResponse
+     * @throws IOException
+     */
+    private void freeHttpConnectionBackToPool(CloseableHttpResponse httpResponse)
+            throws IOException {
+        if (httpResponse != null) {
+            // Prevent the resource leak
+            httpResponse.close();
+        }
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
 
 import java.util.Arrays;
 import java.util.List;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PepCheckHttpRetryStatusConfig.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PepCheckHttpRetryStatusConfig.java
@@ -1,0 +1,64 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import java.util.List;
+
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_HTTP_RETRYER_REQUEST_SEND_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_HTTP_RETRYER_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_HTTP_RETRYER_REQUEST_SEND_RETRY;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_HTTP_RETRYER_SEND_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_HTTP_RETRYER_SEND_MAX_RETRIES;
+
+public class PepCheckHttpRetryStatusConfig implements HttpRetryStatusConfig {
+
+    private final List<Integer> neverRetryCodes = List.of(200);
+
+    private final List<Integer> retryCodes = List.of(429);
+
+    private final List<Integer> successStatusCodes = List.of(200);
+
+    @Override
+    public boolean shouldHttpClientRetry(int statusCode) {
+
+        if (neverRetryCodes.contains(statusCode)) {
+            return false;
+        }
+
+        // Retry all 500 errors
+        if ((statusCode >= 500) && (statusCode <= 599)) {
+            return true;
+        }
+
+        // Only status codes we will retry on
+        return retryCodes.contains(statusCode);
+    }
+
+    @Override
+    public boolean isSuccessStatusCode(int statusCode) {
+        return successStatusCodes.contains(statusCode);
+    }
+
+    @Override
+    public String httpRetryerSendOkMetric() {
+        return PEP_HTTP_RETRYER_REQUEST_SEND_OK.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerSendFailMetric(Exception e) {
+        return PEP_HTTP_RETRYER_REQUEST_SEND_FAIL.withEndpointPrefixAndExceptionName(e);
+    }
+
+    @Override
+    public String httpRetryerSendErrorMetric() {
+        return PEP_HTTP_RETRYER_SEND_ERROR.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerSendRetryMetric() {
+        return PEP_HTTP_RETRYER_REQUEST_SEND_RETRY.withEndpointPrefix();
+    }
+
+    @Override
+    public String httpRetryerMaxRetriesMetric() {
+        return PEP_HTTP_RETRYER_SEND_MAX_RETRIES.withEndpointPrefix();
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactory.java
@@ -1,6 +1,10 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -9,37 +13,29 @@ import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.gateway.*;
 
-import java.io.IOException;
-import java.net.http.HttpClient;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
-import java.time.Duration;
 
 public class ServiceFactory {
     private final IdentityVerificationService identityVerificationService;
     private final ContraindicationMapper contraindicationMapper;
-    private final SSLContextFactory sslContextFactory;
     private final ConfigurationService configurationService;
     private final PersonIdentityValidator personIdentityValidator;
     private final ObjectMapper objectMapper;
-    private final HttpClient httpClient;
     private final AuditService auditService;
 
     private final EventProbe eventProbe;
 
+    private static final int MAX_HTTP_RETRIES = 0;
+
     public ServiceFactory(ObjectMapper objectMapper)
-            throws NoSuchAlgorithmException, InvalidKeyException, IOException {
+            throws NoSuchAlgorithmException, InvalidKeyException {
         this.objectMapper = objectMapper;
         this.eventProbe = new EventProbe();
         this.personIdentityValidator = new PersonIdentityValidator();
         this.configurationService = createConfigurationService();
-        this.sslContextFactory =
-                new SSLContextFactory(
-                        this.configurationService.getEncodedKeyStore(),
-                        this.configurationService.getKeyStorePassword());
         this.contraindicationMapper = new ContraIndicatorRemoteMapper(configurationService);
-        this.httpClient = createHttpClient();
         this.auditService = createAuditService(this.objectMapper);
         this.identityVerificationService = createIdentityVerificationService(this.auditService);
     }
@@ -49,19 +45,15 @@ public class ServiceFactory {
             ObjectMapper objectMapper,
             EventProbe eventProbe,
             ConfigurationService configurationService,
-            SSLContextFactory sslContextFactory,
             ContraindicationMapper contraindicationMapper,
             PersonIdentityValidator personIdentityValidator,
-            HttpClient httpClient,
             AuditService auditService)
             throws NoSuchAlgorithmException, InvalidKeyException {
         this.objectMapper = objectMapper;
         this.eventProbe = eventProbe;
         this.configurationService = configurationService;
-        this.sslContextFactory = sslContextFactory;
         this.contraindicationMapper = contraindicationMapper;
         this.personIdentityValidator = personIdentityValidator;
-        this.httpClient = httpClient;
         this.auditService = auditService;
         this.identityVerificationService = createIdentityVerificationService(this.auditService);
     }
@@ -84,9 +76,25 @@ public class ServiceFactory {
     private IdentityVerificationService createIdentityVerificationService(AuditService auditService)
             throws NoSuchAlgorithmException, InvalidKeyException {
 
-        ThirdPartyFraudGateway thirdPartyGateway =
+        final CloseableHttpClient closeableHttpClient = HttpClients.custom().build();
+
+        final HttpRetryer httpRetryer =
+                new HttpRetryer(closeableHttpClient, eventProbe, MAX_HTTP_RETRIES);
+
+        final ThirdPartyFraudGateway thirdPartyFraudGateway =
                 new ThirdPartyFraudGateway(
-                        httpClient,
+                        httpRetryer,
+                        new IdentityVerificationRequestMapper(
+                                this.configurationService.getTenantId()),
+                        new IdentityVerificationResponseMapper(eventProbe),
+                        this.objectMapper,
+                        new HmacGenerator(configurationService.getHmacKey()),
+                        configurationService.getEndpointUrl(),
+                        eventProbe);
+
+        final ThirdPartyPepGateway thirdPartyPepGateway =
+                new ThirdPartyPepGateway(
+                        httpRetryer,
                         new IdentityVerificationRequestMapper(
                                 this.configurationService.getTenantId()),
                         new IdentityVerificationResponseMapper(eventProbe),
@@ -97,10 +105,13 @@ public class ServiceFactory {
 
         final IdentityScoreCalculator identityScoreCalculator =
                 new IdentityScoreCalculator(configurationService);
+
         final ActivityHistoryScoreCalculator activityHistoryScoreCalculator =
                 new ActivityHistoryScoreCalculator();
+
         return new IdentityVerificationService(
-                thirdPartyGateway,
+                thirdPartyFraudGateway,
+                thirdPartyPepGateway,
                 personIdentityValidator,
                 contraindicationMapper,
                 identityScoreCalculator,
@@ -117,17 +128,17 @@ public class ServiceFactory {
     private AuditService createAuditService(ObjectMapper objectMapper) {
         var commonLibConfigurationService =
                 new uk.gov.di.ipv.cri.common.library.service.ConfigurationService();
+
+        SqsClient sqsClient =
+                SqsClient.builder()
+                        .defaultsMode(DefaultsMode.STANDARD)
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .build();
+
         return new AuditService(
-                SqsClient.builder().build(),
+                sqsClient,
                 commonLibConfigurationService,
                 objectMapper,
                 new AuditEventFactory(commonLibConfigurationService, Clock.systemUTC()));
-    }
-
-    private HttpClient createHttpClient() {
-        return HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .sslContext(this.sslContextFactory.getSSLContext())
-                .build();
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReply.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReply.java
@@ -23,4 +23,16 @@ public class HTTPReply {
 
         throw new IllegalStateException("Not Valid to call no args constructor for this class");
     }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, String> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReply.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReply.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.util.Map;
+
+public class HTTPReply {
+    public final int statusCode;
+    public final Map<String, String> responseHeaders;
+    public final String responseBody;
+
+    public HTTPReply(int statusCode, Map<String, String> responseHeaders, String responseBody) {
+        this.statusCode = statusCode;
+        this.responseHeaders = responseHeaders;
+        this.responseBody = responseBody;
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    private HTTPReply() {
+        statusCode = -1;
+        responseHeaders = null;
+        responseBody = null;
+
+        throw new IllegalStateException("Not Valid to call no args constructor for this class");
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReplyHelper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReplyHelper.java
@@ -1,0 +1,61 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import lombok.experimental.UtilityClass;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.HttpStatusCode;
+import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
+import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@UtilityClass
+public class HTTPReplyHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    // Small helper to avoid duplicating this code for each endpoint and api
+    public static HTTPReply retrieveResponse(HttpResponse response, String endpointName)
+            throws OAuthErrorResponseException {
+        try {
+            Map<String, String> responseHeaders = getAllHeaders(response);
+
+            String mappedBody = EntityUtils.toString(response.getEntity());
+
+            // EntityUtils can return null
+            String responseBody =
+                    (mappedBody) == null
+                            ? String.format("No %s response body text found", endpointName)
+                            : mappedBody;
+            int httpStatusCode = response.getStatusLine().getStatusCode();
+
+            return new HTTPReply(httpStatusCode, responseHeaders, responseBody);
+        } catch (IOException e) {
+
+            LOGGER.error(String.format("IOException retrieving %s response body", endpointName));
+            LOGGER.debug(e.getMessage());
+
+            throw new OAuthErrorResponseException(
+                    HttpStatusCode.INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_RETRIEVE_HTTP_RESPONSE_BODY);
+        }
+    }
+
+    private static Map<String, String> getAllHeaders(HttpResponse response) {
+
+        Map<String, String> headers = new HashMap<>();
+
+        Header[] apacheHeaders = response.getAllHeaders();
+
+        for (Header apacheHeader : apacheHeaders) {
+            headers.put(apacheHeader.getName(), apacheHeader.getValue());
+        }
+
+        return headers;
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/SleepHelper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/SleepHelper.java
@@ -29,35 +29,14 @@ public class SleepHelper {
 
         LOGGER.info("busyWaitWithExponentialBackOff start time : {}", startTime);
 
-        while (System.currentTimeMillis() < futureTime) {}
+        while (System.currentTimeMillis() < futureTime) {
+            // Intended
+        }
 
         long endTime = System.currentTimeMillis();
         long timeWaited = (endTime - startTime);
 
         LOGGER.info("busyWaitWithExponentialBackOff end time : {}", endTime);
-
-        return timeWaited;
-    }
-
-    /**
-     * Calculates a wait time based on number of calls - starting from zero for the first call.
-     * Using Thread.sleep()
-     *
-     * @param callNumber
-     * @return
-     */
-    public long sleepWithExponentialBackOff(int callNumber) throws InterruptedException {
-
-        long startTime = System.currentTimeMillis();
-
-        LOGGER.info("sleepWithExponentialBackOff start time : {}", startTime);
-
-        Thread.sleep(Math.min(calculateExponentialBackOffTimeMS(callNumber), maxSleepTimeMs));
-
-        long endTime = System.currentTimeMillis();
-        long timeWaited = (endTime - startTime);
-
-        LOGGER.info("sleepWithExponentialBackOff end time : {}", endTime);
 
         return timeWaited;
     }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
@@ -7,7 +7,8 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.*;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 
@@ -41,7 +42,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseShouldMapInfoResponse() {
+    void mapFraudResponseShouldMapInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
                 TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
@@ -58,8 +59,7 @@ class IdentityVerificationResponseMapperTest {
         decisionElement.setRules(rules);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
@@ -82,8 +82,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.getResponseHeader().setTenantID(null);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
@@ -99,7 +98,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseShouldMapWarnResponse() {
+    void mapFraudResponseShouldMapWarnResponse() {
         String responseCode = "response-code";
         String responseMessage = "response-message";
         final ResponseType TYPE = ResponseType.WARN;
@@ -114,8 +113,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -141,7 +139,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseShouldMapWarningResponse() {
+    void mapFraudResponseShouldMapWarningResponse() {
         String responseCode = "response-code";
         String responseMessage = "response-message";
         final ResponseType TYPE = ResponseType.WARNING;
@@ -156,8 +154,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -183,7 +180,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseShouldMapErrorResponse() {
+    void mapFraudResponseShouldMapErrorResponse() {
         String responseCode = "response-code";
         String responseMessage = "response-message";
         final ResponseType TYPE = ResponseType.ERROR;
@@ -198,8 +195,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -225,7 +221,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeNullWithNullResponseCode() {
+    void mapFraudResponseFraudCheckErrorMessageCannotBeNullWithNullResponseCode() {
         String responseCode = null;
         String responseMessage = "response-message";
         final ResponseType TYPE = ResponseType.ERROR;
@@ -240,8 +236,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -268,7 +263,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseCode() {
+    void mapFraudResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseCode() {
         String responseCode = "";
         String responseMessage = "response-message";
         final ResponseType TYPE = ResponseType.ERROR;
@@ -283,8 +278,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -311,8 +305,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void
-            mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeNullWithNullResponseMessage() {
+    void mapFraudResponseFraudCheckErrorMessageCannotBeNullWithNullResponseMessage() {
         String responseCode = "response-code";
         String responseMessage = null;
         final ResponseType TYPE = ResponseType.ERROR;
@@ -327,8 +320,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -355,8 +347,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void
-            mapIdentityVerificationResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseMessage() {
+    void mapFraudResponseFraudCheckErrorMessageCannotBeEmptyWithEmptyResponseMessage() {
         String responseCode = "response-code";
         String responseMessage = "";
         final ResponseType TYPE = ResponseType.ERROR;
@@ -371,8 +362,7 @@ class IdentityVerificationResponseMapperTest {
         testIdentityVerificationResponse.setResponseHeader(responseHeader);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_ERROR);
 
@@ -411,18 +401,18 @@ class IdentityVerificationResponseMapperTest {
         List<Rule> rules = List.of(rule);
         decisionElement.setRules(rules);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO);
         inOrder.verify(mockEventProbe)
                 .counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO_VALIDATION_PASS);
 
-        assertNotNull(fraudCheckResult);
-        assertTrue(fraudCheckResult.isExecutedSuccessfully());
-        assertNull(fraudCheckResult.getErrorMessage());
-        assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
+        assertNotNull(pepCheckResult);
+        assertTrue(pepCheckResult.isExecutedSuccessfully());
+        assertNull(pepCheckResult.getErrorMessage());
+        assertEquals(1, pepCheckResult.getThirdPartyFraudCodes().length);
+        assertEquals(rule.getRuleId(), pepCheckResult.getThirdPartyFraudCodes()[0]);
     }
 
     @Test
@@ -431,7 +421,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.getResponseHeader().setTenantID(null);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_INFO);
@@ -441,9 +431,9 @@ class IdentityVerificationResponseMapperTest {
         final String EXPECTED_ERROR =
                 IdentityVerificationResponseMapper.IV_INFO_RESPONSE_VALIDATION_FAILED_MSG;
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
     }
 
     @Test
@@ -460,7 +450,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -475,10 +465,10 @@ class IdentityVerificationResponseMapperTest {
                         responseCode,
                         responseMessage);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -495,7 +485,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -510,10 +500,10 @@ class IdentityVerificationResponseMapperTest {
                         responseCode,
                         responseMessage);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -530,7 +520,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -545,10 +535,10 @@ class IdentityVerificationResponseMapperTest {
                         responseCode,
                         responseMessage);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -565,7 +555,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -581,10 +571,10 @@ class IdentityVerificationResponseMapperTest {
                                 .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK,
                         responseMessage);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -601,7 +591,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -617,10 +607,10 @@ class IdentityVerificationResponseMapperTest {
                                 .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK,
                         responseMessage);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -637,7 +627,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -653,10 +643,10 @@ class IdentityVerificationResponseMapperTest {
                         IdentityVerificationResponseMapper
                                 .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
@@ -673,7 +663,7 @@ class IdentityVerificationResponseMapperTest {
 
         testPEPResponse.setResponseHeader(responseHeader);
 
-        FraudCheckResult fraudCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
+        PepCheckResult pepCheckResult = this.responseMapper.mapPEPResponse(testPEPResponse);
 
         verify(mockEventProbe).counterMetric(THIRD_PARTY_PEP_RESPONSE_TYPE_ERROR);
 
@@ -689,14 +679,14 @@ class IdentityVerificationResponseMapperTest {
                         IdentityVerificationResponseMapper
                                 .IV_ERROR_RESPONSE_ERROR_MESSAGE_DEFAULT_FIELD_VALUE_IF_BLANK);
 
-        assertNotNull(fraudCheckResult);
-        assertFalse(fraudCheckResult.isExecutedSuccessfully());
-        assertEquals(EXPECTED_ERROR, fraudCheckResult.getErrorMessage());
-        assertEquals(0, fraudCheckResult.getThirdPartyFraudCodes().length);
+        assertNotNull(pepCheckResult);
+        assertFalse(pepCheckResult.isExecutedSuccessfully());
+        assertEquals(EXPECTED_ERROR, pepCheckResult.getErrorMessage());
+        assertEquals(0, pepCheckResult.getThirdPartyFraudCodes().length);
     }
 
     @Test
-    void mapIdentityVerificationResponseWithEmptyDataCountsShouldReturnInfoResponse() {
+    void mapFraudResponseWithEmptyDataCountsShouldReturnInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
                 TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
@@ -716,8 +706,7 @@ class IdentityVerificationResponseMapperTest {
         decisionElement.setDataCounts(dataCounts);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
@@ -741,7 +730,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseWithNullDataCountsShouldReturnInfoResponse() {
+    void mapFraudResponseWithNullDataCountsShouldReturnInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
                 TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
@@ -761,8 +750,7 @@ class IdentityVerificationResponseMapperTest {
         decisionElement.setDataCounts(dataCounts);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
@@ -786,7 +774,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseWithInvalidDataCountsShouldReturnInfoResponse() {
+    void mapFraudResponseWithInvalidDataCountsShouldReturnInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
                 TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
@@ -820,8 +808,7 @@ class IdentityVerificationResponseMapperTest {
         decisionElement.setDataCounts(dataCounts);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);
@@ -845,7 +832,7 @@ class IdentityVerificationResponseMapperTest {
     }
 
     @Test
-    void mapIdentityVerificationResponseWithValidDataCountValuesShouldReturnInfoResponse() {
+    void mapFraudResponseWithValidDataCountValuesShouldReturnInfoResponse() {
         IdentityVerificationResponse testIdentityVerificationResponse =
                 TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
 
@@ -879,8 +866,7 @@ class IdentityVerificationResponseMapperTest {
         decisionElement.setDataCounts(dataCounts);
 
         FraudCheckResult fraudCheckResult =
-                this.responseMapper.mapIdentityVerificationResponse(
-                        testIdentityVerificationResponse);
+                this.responseMapper.mapFraudResponse(testIdentityVerificationResponse);
 
         InOrder inOrder = inOrder(mockEventProbe);
         inOrder.verify(mockEventProbe).counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
@@ -1,31 +1,33 @@
 package uk.gov.di.ipv.cri.fraud.api.gateway;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpPost;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
-import uk.gov.di.ipv.cri.fraud.api.util.SleepHelper;
+import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
+import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
+import uk.gov.di.ipv.cri.fraud.api.util.HttpResponseFixtures;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
-
-import javax.net.ssl.SSLSession;
+import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpHeaders;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.Optional;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,193 +35,173 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyDouble;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_CREATED;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_CREATED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_VALID;
 
 @ExtendWith(MockitoExtension.class)
 class ThirdPartyFraudGatewayComponentTest {
 
     private static final String TEST_ENDPOINT_URL = "https://test-endpoint.co.uk";
-    private ThirdPartyFraudGateway thirdPartyFraudGateway;
-    @Mock private HttpClient mockHttpClient;
+    private ThirdPartyPepGateway thirdPartyPepGateway;
+    @Mock private HttpRetryer mockHttpRetryer;
     @Mock private IdentityVerificationRequestMapper mockRequestMapper;
     @Mock private IdentityVerificationResponseMapper mockResponseMapper;
     @Mock private HmacGenerator mockHmacGenerator;
-    @Mock private SleepHelper sleepHelper;
     @Mock private EventProbe mockEventProbe;
 
     @BeforeEach
     void setUp() {
-        this.thirdPartyFraudGateway =
-                new ThirdPartyFraudGateway(
-                        mockHttpClient,
+        this.thirdPartyPepGateway =
+                new ThirdPartyPepGateway(
+                        mockHttpRetryer,
                         mockRequestMapper,
                         mockResponseMapper,
                         new ObjectMapper(),
                         mockHmacGenerator,
                         TEST_ENDPOINT_URL,
-                        sleepHelper,
                         mockEventProbe);
     }
 
     @Test
-    void testPepsResponseBodyCanBeDeserialized() throws IOException, InterruptedException {
+    void testPepsResponseBodyCanBeDeserialized() throws IOException, OAuthErrorResponseException {
         final PEPRequest testApiRequest = new PEPRequest();
 
         final String hmacOfRequestBody = "hmac-of-request-body";
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
-        IdentityVerificationResponse testResponse = new IdentityVerificationResponse();
-        FraudCheckResult testFraudCheckResult = new FraudCheckResult();
+        PepCheckResult testPepCheckResult = new PepCheckResult();
         when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
 
-        when(this.mockHmacGenerator.generateHmac(anyString())).thenReturn(hmacOfRequestBody);
-        ArgumentCaptor<HttpRequest> httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        when(this.mockHttpClient.send(
-                        httpRequestCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString())))
-                .thenReturn(
-                        createMockApiResponse(
-                                200,
-                                "{\n"
-                                        + "\t\"responseHeader\": {\n"
-                                        + "\t\t\"requestType\": \"PepSanctions01\",\n"
-                                        + "\t\t\"clientReferenceId\": \"2b58b407-60bc-4356-849c-e6b0ac9dc32a\",\n"
-                                        + "\t\t\"expRequestId\": \"123456789\",\n"
-                                        + "\t\t\"messageTime\": \"2023-02-22T18:42:59Z\",\n"
-                                        + "\t\t\"overallResponse\": {\n"
-                                        + "\t\t\t\"decision\": \"CONTINUE\",\n"
-                                        + "\t\t\t\"decisionText\": \"Continue\",\n"
-                                        + "\t\t\t\"decisionReasons\": [\"No matches present\"],\n"
-                                        + "\t\t\t\"recommendedNextActions\": [],\n"
-                                        + "\t\t\t\"spareObjects\": []\n"
-                                        + "\t\t},\n"
-                                        + "\t\t\"responseCode\": \"R0201\",\n"
-                                        + "\t\t\"responseType\": \"INFO\",\n"
-                                        + "\t\t\"responseMessage\": \"Workflow Complete.\",\n"
-                                        + "\t\t\"tenantID\": \"123456\"\n"
-                                        + "\t},\n"
-                                        + "\t\"clientResponsePayload\": {\n"
-                                        + "\t\t\"orchestrationDecisions\": [{\n"
-                                        + "\t\t\t\"sequenceId\": \"1\",\n"
-                                        + "\t\t\t\"decisionSource\": \"Hunter\",\n"
-                                        + "\t\t\t\"decision\": \"NO\",\n"
-                                        + "\t\t\t\"decisionReasons\": [\"No relevant Hunter matches present\"],\n"
-                                        + "\t\t\t\"score\": 0,\n"
-                                        + "\t\t\t\"decisionText\": \"No relevant Matches\",\n"
-                                        + "\t\t\t\"nextAction\": \"Continue\",\n"
-                                        + "\t\t\t\"decisionTime\": \"2023-02-22T18:43:00Z\"\n"
-                                        + "\t\t}],\n"
-                                        + "\t\t\"decisionElements\": [{\n"
-                                        + "\t\t\t\"serviceName\": \"Peps\",\n"
-                                        + "\t\t\t\"score\": 0,\n"
-                                        + "\t\t\t\"appReference\": \"2b58b407-60bc-4356-849c-e6b0ac9dc32a\",\n"
-                                        + "\t\t\t\"otherData\": {\n"
-                                        + "\t\t\t\t\"response\": {\n"
-                                        + "\t\t\t\t\t\"matchSummary\": {\n"
-                                        + "\t\t\t\t\t\t\"totalMatchScore\": \"0\",\n"
-                                        + "\t\t\t\t\t\t\"submissionScores\": {\n"
-                                        + "\t\t\t\t\t\t\t\"scoreType\": [{\n"
-                                        + "\t\t\t\t\t\t\t\t\"scoreValue\": [{\n"
-                                        + "\t\t\t\t\t\t\t\t\t\"value\": 50,\n"
-                                        + "\t\t\t\t\t\t\t\t\t\"currentVersion\": \"TRUE\"\n"
-                                        + "\t\t\t\t\t\t\t\t}],\n"
-                                        + "\t\t\t\t\t\t\t\t\"scoreCount\": 1\n"
-                                        + "\t\t\t\t\t\t\t}],\n"
-                                        + "\t\t\t\t\t\t\t\"matches\": 1\n"
-                                        + "\t\t\t\t\t\t},\n"
-                                        + "\t\t\t\t\t\t\"errorWarnings\": {\n"
-                                        + "\t\t\t\t\t\t\t\"errors\": {\n"
-                                        + "\t\t\t\t\t\t\t\t\"error\": [],\n"
-                                        + "\t\t\t\t\t\t\t\t\"errorCount\": 0\n"
-                                        + "\t\t\t\t\t\t\t},\n"
-                                        + "\t\t\t\t\t\t\t\"warnings\": {\n"
-                                        + "\t\t\t\t\t\t\t\t\"warning\": [],\n"
-                                        + "\t\t\t\t\t\t\t\t\"warningCount\": 0\n"
-                                        + "\t\t\t\t\t\t\t}\n"
-                                        + "\t\t\t\t\t\t}\n"
-                                        + "\t\t\t\t\t}\n"
-                                        + "\t\t\t\t},\n"
-                                        + "\t\t\t\t\"scores\": []\n"
-                                        + "\n"
-                                        + "\t\t\t},\n"
-                                        + "\t\t\t\"originalRequestData\": {}\n"
-                                        + "\t\t}]\n"
-                                        + "\t}\n"
-                                        + "}"));
+        when(mockHmacGenerator.generateHmac(anyString())).thenReturn(hmacOfRequestBody);
+
+        ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor =
+                ArgumentCaptor.forClass(HttpPost.class);
+
+        String responseBody =
+                "{\n"
+                        + "\t\"responseHeader\": {\n"
+                        + "\t\t\"requestType\": \"PepSanctions01\",\n"
+                        + "\t\t\"clientReferenceId\": \"2b58b407-60bc-4356-849c-e6b0ac9dc32a\",\n"
+                        + "\t\t\"expRequestId\": \"123456789\",\n"
+                        + "\t\t\"messageTime\": \"2023-02-22T18:42:59Z\",\n"
+                        + "\t\t\"overallResponse\": {\n"
+                        + "\t\t\t\"decision\": \"CONTINUE\",\n"
+                        + "\t\t\t\"decisionText\": \"Continue\",\n"
+                        + "\t\t\t\"decisionReasons\": [\"No matches present\"],\n"
+                        + "\t\t\t\"recommendedNextActions\": [],\n"
+                        + "\t\t\t\"spareObjects\": []\n"
+                        + "\t\t},\n"
+                        + "\t\t\"responseCode\": \"R0201\",\n"
+                        + "\t\t\"responseType\": \"INFO\",\n"
+                        + "\t\t\"responseMessage\": \"Workflow Complete.\",\n"
+                        + "\t\t\"tenantID\": \"123456\"\n"
+                        + "\t},\n"
+                        + "\t\"clientResponsePayload\": {\n"
+                        + "\t\t\"orchestrationDecisions\": [{\n"
+                        + "\t\t\t\"sequenceId\": \"1\",\n"
+                        + "\t\t\t\"decisionSource\": \"Hunter\",\n"
+                        + "\t\t\t\"decision\": \"NO\",\n"
+                        + "\t\t\t\"decisionReasons\": [\"No relevant Hunter matches present\"],\n"
+                        + "\t\t\t\"score\": 0,\n"
+                        + "\t\t\t\"decisionText\": \"No relevant Matches\",\n"
+                        + "\t\t\t\"nextAction\": \"Continue\",\n"
+                        + "\t\t\t\"decisionTime\": \"2023-02-22T18:43:00Z\"\n"
+                        + "\t\t}],\n"
+                        + "\t\t\"decisionElements\": [{\n"
+                        + "\t\t\t\"serviceName\": \"Peps\",\n"
+                        + "\t\t\t\"score\": 0,\n"
+                        + "\t\t\t\"appReference\": \"2b58b407-60bc-4356-849c-e6b0ac9dc32a\",\n"
+                        + "\t\t\t\"otherData\": {\n"
+                        + "\t\t\t\t\"response\": {\n"
+                        + "\t\t\t\t\t\"matchSummary\": {\n"
+                        + "\t\t\t\t\t\t\"totalMatchScore\": \"0\",\n"
+                        + "\t\t\t\t\t\t\"submissionScores\": {\n"
+                        + "\t\t\t\t\t\t\t\"scoreType\": [{\n"
+                        + "\t\t\t\t\t\t\t\t\"scoreValue\": [{\n"
+                        + "\t\t\t\t\t\t\t\t\t\"value\": 50,\n"
+                        + "\t\t\t\t\t\t\t\t\t\"currentVersion\": \"TRUE\"\n"
+                        + "\t\t\t\t\t\t\t\t}],\n"
+                        + "\t\t\t\t\t\t\t\t\"scoreCount\": 1\n"
+                        + "\t\t\t\t\t\t\t}],\n"
+                        + "\t\t\t\t\t\t\t\"matches\": 1\n"
+                        + "\t\t\t\t\t\t},\n"
+                        + "\t\t\t\t\t\t\"errorWarnings\": {\n"
+                        + "\t\t\t\t\t\t\t\"errors\": {\n"
+                        + "\t\t\t\t\t\t\t\t\"error\": [],\n"
+                        + "\t\t\t\t\t\t\t\t\"errorCount\": 0\n"
+                        + "\t\t\t\t\t\t\t},\n"
+                        + "\t\t\t\t\t\t\t\"warnings\": {\n"
+                        + "\t\t\t\t\t\t\t\t\"warning\": [],\n"
+                        + "\t\t\t\t\t\t\t\t\"warningCount\": 0\n"
+                        + "\t\t\t\t\t\t\t}\n"
+                        + "\t\t\t\t\t\t}\n"
+                        + "\t\t\t\t\t}\n"
+                        + "\t\t\t\t},\n"
+                        + "\t\t\t\t\"scores\": []\n"
+                        + "\n"
+                        + "\t\t\t},\n"
+                        + "\t\t\t\"originalRequestData\": {}\n"
+                        + "\t\t}]\n"
+                        + "\t}\n"
+                        + "}";
+
+        CloseableHttpResponse closeableHttpResponse =
+                HttpResponseFixtures.createHttpResponse(200, null, responseBody, false);
+
+        when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class)))
+                .thenReturn(closeableHttpResponse);
 
         when(this.mockResponseMapper.mapPEPResponse(any(PEPResponse.class)))
-                .thenReturn(testFraudCheckResult);
+                .thenReturn(testPepCheckResult);
 
-        FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity, true);
+        PepCheckResult actualPepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity);
 
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_CREATED);
-        verify(mockEventProbe, times(1)).counterMetric(THIRD_PARTY_REQUEST_SEND_OK);
-        verify(mockEventProbe, times(1))
+        InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
                 .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_VALID.withEndpointPrefix());
+        verifyNoMoreInteractions(mockEventProbe);
 
         verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockHmacGenerator).generateHmac(anyString());
-        verify(mockHttpClient)
-                .send(any(HttpRequest.class), eq(HttpResponse.BodyHandlers.ofString()));
+        verify(mockHttpRetryer)
+                .sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class));
         verify(mockResponseMapper).mapPEPResponse(any(PEPResponse.class));
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().uri().toString());
-        assertEquals("POST", httpRequestCaptor.getValue().method());
-        HttpHeaders capturedHttpRequestHeaders = httpRequestCaptor.getValue().headers();
-        assertEquals("application/json", capturedHttpRequestHeaders.firstValue("Accept").get());
-        assertEquals(
-                "application/json", capturedHttpRequestHeaders.firstValue("Content-Type").get());
-        assertEquals(
-                hmacOfRequestBody, capturedHttpRequestHeaders.firstValue("hmac-signature").get());
-    }
 
-    private HttpResponse<String> createMockApiResponse(int statusCode, String response) {
+        assertNotNull(actualPepCheckResult);
+        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
 
-        return new HttpResponse<>() {
-            @Override
-            public int statusCode() {
-                return statusCode;
-            }
+        // Check Headers
+        Map<String, String> httpHeadersKV =
+                Arrays.stream(httpRequestCaptor.getValue().getAllHeaders())
+                        .collect(Collectors.toMap(Header::getName, Header::getValue));
 
-            @Override
-            public HttpRequest request() {
-                return null;
-            }
+        assertNotNull(httpHeadersKV.get("Content-Type"));
+        assertEquals("application/json", httpHeadersKV.get("Content-Type"));
 
-            @Override
-            public Optional<HttpResponse<String>> previousResponse() {
-                return Optional.empty();
-            }
-
-            @Override
-            public HttpHeaders headers() {
-                return null;
-            }
-
-            @Override
-            public String body() {
-                return response;
-            }
-
-            @Override
-            public Optional<SSLSession> sslSession() {
-                return Optional.empty();
-            }
-
-            @Override
-            public URI uri() {
-                return null;
-            }
-
-            @Override
-            public HttpClient.Version version() {
-                return null;
-            }
-        };
+        assertNotNull(httpHeadersKV.get("Content-Type"));
+        assertEquals(hmacOfRequestBody, httpHeadersKV.get("hmac-signature"));
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.cri.fraud.api.gateway;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +19,7 @@ import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
 import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
-import uk.gov.di.ipv.cri.fraud.api.util.HttpResponseFixtures;
+import uk.gov.di.ipv.cri.fraud.api.util.HTTPReply;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 
@@ -152,12 +151,13 @@ class ThirdPartyFraudGatewayComponentTest {
                         + "\t}\n"
                         + "}";
 
-        CloseableHttpResponse closeableHttpResponse =
-                HttpResponseFixtures.createHttpResponse(200, null, responseBody, false);
+        HTTPReply httpReply = new HTTPReply(200, null, responseBody);
 
         when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class)))
-                .thenReturn(closeableHttpResponse);
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check")))
+                .thenReturn(httpReply);
 
         when(this.mockResponseMapper.mapPEPResponse(any(PEPResponse.class)))
                 .thenReturn(testPepCheckResult);
@@ -186,7 +186,9 @@ class ThirdPartyFraudGatewayComponentTest {
         verify(mockHmacGenerator).generateHmac(anyString());
         verify(mockHttpRetryer)
                 .sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class));
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check"));
         verify(mockResponseMapper).mapPEPResponse(any(PEPResponse.class));
 
         assertNotNull(actualPepCheckResult);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
@@ -18,11 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.IdentityVerificationRequest;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
-import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckHttpRetryStatusConfig;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
+import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.util.HttpResponseFixtures;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
@@ -38,26 +38,30 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.ERROR_FRAUD_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_REQUEST_CREATED;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_REQUEST_SEND_OK;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_INVALID;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.FRAUD_RESPONSE_TYPE_VALID;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse.ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_CREATED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_INVALID;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetric.PEP_RESPONSE_TYPE_VALID;
 
 @ExtendWith(MockitoExtension.class)
-class ThirdPartyFraudGatewayTest {
+class ThirdPartyPepGatewayTest {
 
     private static final String TEST_API_RESPONSE_BODY = "test-api-response-content";
     private static final String TEST_ENDPOINT_URL = "https://test-endpoint.co.uk";
 
     private static final String HMAC_OF_REQUEST_BODY = "hmac-of-request-body";
 
-    private ThirdPartyFraudGateway thirdPartyFraudGateway;
+    private ThirdPartyPepGateway thirdPartyPepGateway;
 
     @Mock private HttpRetryer mockHttpRetryer;
 
@@ -69,8 +73,8 @@ class ThirdPartyFraudGatewayTest {
 
     @BeforeEach
     void setUp() {
-        this.thirdPartyFraudGateway =
-                new ThirdPartyFraudGateway(
+        thirdPartyPepGateway =
+                new ThirdPartyPepGateway(
                         mockHttpRetryer,
                         mockRequestMapper,
                         mockResponseMapper,
@@ -81,15 +85,15 @@ class ThirdPartyFraudGatewayTest {
     }
 
     @Test
-    void shouldInvokeExperianApi() throws IOException, OAuthErrorResponseException {
-        final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+    void shouldInvokePepApi() throws IOException, OAuthErrorResponseException {
+        final String testRequestBody = "serialisedPepApiRequest";
+        final PEPRequest testApiRequest = new PEPRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
-        IdentityVerificationResponse testResponse = new IdentityVerificationResponse();
-        FraudCheckResult testFraudCheckResult = new FraudCheckResult();
-        when(mockRequestMapper.mapPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+        PEPResponse testPepResponse = new PEPResponse();
+        PepCheckResult testPepCheckResult = new PepCheckResult();
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
 
         when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
         when(this.mockHmacGenerator.generateHmac(testRequestBody)).thenReturn(HMAC_OF_REQUEST_BODY);
@@ -97,46 +101,45 @@ class ThirdPartyFraudGatewayTest {
                 ArgumentCaptor.forClass(HttpPost.class);
 
         when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class)))
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class)))
                 .thenReturn(
                         HttpResponseFixtures.createHttpResponse(
                                 200, null, TEST_API_RESPONSE_BODY, false));
 
-        when(this.mockObjectMapper.readValue(
-                        TEST_API_RESPONSE_BODY, IdentityVerificationResponse.class))
-                .thenReturn(testResponse);
-        when(this.mockResponseMapper.mapFraudResponse(testResponse))
-                .thenReturn(testFraudCheckResult);
+        when(this.mockObjectMapper.readValue(TEST_API_RESPONSE_BODY, PEPResponse.class))
+                .thenReturn(testPepResponse);
+        when(this.mockResponseMapper.mapPEPResponse(testPepResponse))
+                .thenReturn(testPepCheckResult);
 
-        FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+        PepCheckResult actualPepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_CREATED.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS), anyDouble());
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+                .counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_RESPONSE_TYPE_VALID.withEndpointPrefix());
+                .counterMetric(PEP_RESPONSE_TYPE_VALID.withEndpointPrefix());
         verifyNoMoreInteractions(mockEventProbe);
 
-        verify(mockRequestMapper).mapPersonIdentity(personIdentity);
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
         verify(mockHmacGenerator).generateHmac(testRequestBody);
         verify(mockHttpRetryer)
                 .sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class));
-        verify(mockResponseMapper).mapFraudResponse(testResponse);
-        assertNotNull(actualFraudCheckResult);
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class));
+        verify(mockResponseMapper).mapPEPResponse(testPepResponse);
+
+        assertNotNull(actualPepCheckResult);
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
         assertHeaders(httpRequestCaptor);
@@ -146,12 +149,12 @@ class ThirdPartyFraudGatewayTest {
     void shouldReturnOAuthErrorResponseExceptionIfThirdPartyApiReturnsInvalidResponse()
             throws IOException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+        final PEPRequest testApiRequest = new PEPRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
 
-        when(mockRequestMapper.mapPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
 
         when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
         when(this.mockHmacGenerator.generateHmac(testRequestBody)).thenReturn(HMAC_OF_REQUEST_BODY);
@@ -159,17 +162,17 @@ class ThirdPartyFraudGatewayTest {
                 ArgumentCaptor.forClass(HttpPost.class);
 
         when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class)))
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class)))
                 .thenReturn(
                         HttpResponseFixtures.createHttpResponse(200, null, "}BAD JSON{", false));
 
         OAuthErrorResponseException expectedReturnedException =
                 new OAuthErrorResponseException(
                         HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                        ErrorResponse.FAILED_TO_MAP_FRAUD_CHECK_RESPONSE_BODY);
+                        ErrorResponse.FAILED_TO_MAP_PEP_CHECK_RESPONSE_BODY);
 
         // Trigger the mapping failure via the mock
-        when(mockObjectMapper.readValue("}BAD JSON{", IdentityVerificationResponse.class))
+        when(mockObjectMapper.readValue("}BAD JSON{", PEPResponse.class))
                 .thenThrow(
                         new InputCoercionException(
                                 null, "Problem during json mapping", null, null));
@@ -177,7 +180,7 @@ class ThirdPartyFraudGatewayTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> thirdPartyFraudGateway.performFraudCheck(personIdentity),
+                        () -> thirdPartyPepGateway.performPepCheck(personIdentity),
                         "Expected OAuthErrorResponseException");
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -186,27 +189,27 @@ class ThirdPartyFraudGatewayTest {
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_CREATED.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS), anyDouble());
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+                .counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_RESPONSE_TYPE_INVALID.withEndpointPrefix());
+                .counterMetric(PEP_RESPONSE_TYPE_INVALID.withEndpointPrefix());
         verifyNoMoreInteractions(mockEventProbe);
 
-        verify(mockRequestMapper).mapPersonIdentity(personIdentity);
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
         verify(mockHmacGenerator).generateHmac(testRequestBody);
         verify(mockHttpRetryer)
                 .sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class));
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class));
 
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
@@ -217,14 +220,14 @@ class ThirdPartyFraudGatewayTest {
     @CsvSource({
         "300", "400", "500", "-1",
     })
-    void thirdPartyApiReturnsErrorOnUnexpectedHTTPStatusResponse(int errorStatus)
+    void thirdPartyApiReturnsErrorOnHTTP300Response(int errorStatus)
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+        final PEPRequest testApiRequest = new PEPRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
-        when(mockRequestMapper.mapPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
 
         when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
 
@@ -233,42 +236,41 @@ class ThirdPartyFraudGatewayTest {
                 ArgumentCaptor.forClass(HttpPost.class);
 
         when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class)))
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class)))
                 .thenReturn(
                         HttpResponseFixtures.createHttpResponse(
                                 errorStatus, null, TEST_API_RESPONSE_BODY, false));
 
-        FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity);
+        PepCheckResult actualPepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_CREATED.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_REQUEST_SEND_OK.withEndpointPrefix());
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(eq(THIRD_PARTY_FRAUD_RESPONSE_LATENCY_MILLIS), anyDouble());
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
         inOrderMockEventProbe
                 .verify(mockEventProbe)
-                .counterMetric(FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
+                .counterMetric(PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
         verifyNoMoreInteractions(mockEventProbe);
 
         final String EXPECTED_ERROR =
-                ERROR_FRAUD_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE.getMessage();
+                ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE.getMessage();
 
-        verify(mockRequestMapper).mapPersonIdentity(personIdentity);
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
         verify(mockObjectMapper).writeValueAsString(testApiRequest);
         verify(mockHmacGenerator).generateHmac(testRequestBody);
 
         verify(mockHttpRetryer, times(1))
                 .sendHTTPRequestRetryIfAllowed(
-                        httpRequestCaptor.capture(), any(FraudCheckHttpRetryStatusConfig.class));
+                        httpRequestCaptor.capture(), any(PepCheckHttpRetryStatusConfig.class));
 
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
+        assertNotNull(actualPepCheckResult);
+        assertEquals(EXPECTED_ERROR, actualPepCheckResult.getErrorMessage());
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
         assertHeaders(httpRequestCaptor);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/HttpRetryerTest.java
@@ -1,0 +1,200 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.fraud.api.util.HttpResponseFixtures;
+import uk.gov.di.ipv.cri.fraud.api.util.HttpRetryStatusConfigFixtures;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HttpRetryerTest {
+
+    @Mock private CloseableHttpClient mockHttpClient;
+    @Mock private EventProbe mockEventProbe;
+
+    private HttpRetryer httpRetryer;
+    @Mock private HttpPost mockPostRequest;
+
+    private List<Integer> TEST_RETRY_STATUS_CODES = List.of(300, 400, 500);
+    private List<Integer> TEST_SUCCESS_STATUS_CODES = List.of(200, 201);
+    private int TEST_MAX_RETRIES = 3;
+
+    @BeforeEach
+    void setUp() {
+        httpRetryer = new HttpRetryer(mockHttpClient, mockEventProbe, TEST_MAX_RETRIES);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "200, false", // No Retry
+        "201, false", // No Retry
+        "300, true", // Retry Expected
+        "400, true", // Retry Expected
+        "500, true", // Retry Expected
+    })
+    void shouldOnlyRetryWhenStatusIsAMatchingRetryCode(int statusCode, boolean retryExpected)
+            throws IOException {
+
+        CloseableHttpResponse testCloseableHttpResponse =
+                HttpResponseFixtures.createHttpResponse(statusCode, null, "", false);
+
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(testCloseableHttpResponse);
+
+        HttpRetryStatusConfig testHttpRetryStatusConfig =
+                HttpRetryStatusConfigFixtures.generateTestReplyStatusConfig(
+                        TEST_RETRY_STATUS_CODES, TEST_SUCCESS_STATUS_CODES);
+        httpRetryer.sendHTTPRequestRetryIfAllowed(mockPostRequest, testHttpRetryStatusConfig);
+
+        int mockHttpClientExpectedTimes = 1; // 1 for the initial attempt
+        if (retryExpected) {
+            mockHttpClientExpectedTimes += TEST_MAX_RETRIES;
+
+            InOrder inOrderMockEventProbeSequence = inOrder(mockEventProbe);
+            inOrderMockEventProbeSequence
+                    .verify(mockEventProbe, times(TEST_MAX_RETRIES))
+                    .counterMetric(
+                            HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_RETRY_METRIC);
+            inOrderMockEventProbeSequence
+                    .verify(mockEventProbe, times(1))
+                    .counterMetric(
+                            HttpRetryStatusConfigFixtures
+                                    .TEST_HTTP_RETRYER_SEND_MAX_RETRIES_METRIC);
+        } else {
+            // Send Success
+            verify(mockEventProbe)
+                    .counterMetric(HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_OK_METRIC);
+        }
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockHttpClient, times(mockHttpClientExpectedTimes)).execute(any(HttpPost.class));
+        verifyNoMoreInteractions(mockHttpClient);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "IOException, false", // No Retry
+        "ConnectTimeoutException, true", // Retry Expected
+        "SocketTimeoutException, true", // Retry Expected
+    })
+    void shouldOnlyRetryWhenIOExceptionIsARetryableException(
+            String exceptionToThrow, boolean retryExpected) throws IOException {
+
+        final Exception exception;
+
+        if (exceptionToThrow.equals("ConnectTimeoutException")) {
+            exception = new ConnectTimeoutException("TestConnectTimeoutException");
+        } else if (exceptionToThrow.equals("SocketTimeoutException")) {
+            exception = new SocketTimeoutException("TestSocketTimeoutException");
+        } else {
+            exception = new IOException("TestGeneralIOException");
+        }
+
+        when(mockHttpClient.execute(any(HttpPost.class))).thenThrow(exception);
+
+        HttpRetryStatusConfig testHttpRetryStatusConfig =
+                HttpRetryStatusConfigFixtures.generateTestReplyStatusConfig(
+                        TEST_RETRY_STATUS_CODES, TEST_SUCCESS_STATUS_CODES);
+
+        IOException thrownException =
+                assertThrows(
+                        IOException.class,
+                        () ->
+                                httpRetryer.sendHTTPRequestRetryIfAllowed(
+                                        mockPostRequest, testHttpRetryStatusConfig),
+                        "Expected IOException");
+
+        int mockHttpClientExpectedTimes = 1; // The initial attempt
+        if (retryExpected) {
+            mockHttpClientExpectedTimes += TEST_MAX_RETRIES;
+
+            InOrder inOrderMockEventProbeSequence = inOrder(mockEventProbe);
+            // x3 retries
+            inOrderMockEventProbeSequence
+                    .verify(mockEventProbe, times(TEST_MAX_RETRIES))
+                    .counterMetric(
+                            HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_RETRY_METRIC);
+            inOrderMockEventProbeSequence
+                    .verify(mockEventProbe)
+                    .counterMetric(
+                            HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_FAIL_METRIC);
+
+            // No retry after final attempt, Exception rethrown
+            if (exceptionToThrow.equals("ConnectTimeoutException")) {
+                assertTrue(thrownException instanceof ConnectTimeoutException);
+            } else if (exceptionToThrow.equals("SocketTimeoutException")) {
+                assertTrue(thrownException instanceof SocketTimeoutException);
+            }
+        } else {
+            // Send Fail - IOException
+            verify(mockEventProbe)
+                    .counterMetric(
+                            HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_FAIL_METRIC);
+            assertTrue(thrownException instanceof IOException);
+        }
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockHttpClient, times(mockHttpClientExpectedTimes)).execute(any(HttpPost.class));
+        verifyNoMoreInteractions(mockHttpClient);
+    }
+
+    @Test
+    void shouldCaptureSendErrorMetricIfRemoteAPIReturnsNonRetryableStatusDuringARetry()
+            throws IOException {
+
+        // Response with retryable status code
+        CloseableHttpResponse initialRetryableCloseableHttpResponse =
+                HttpResponseFixtures.createHttpResponse(500, null, "", false);
+
+        // 999 status is not in the success list or in the retry list
+        CloseableHttpResponse nonRetryableCloseableHttpResponse =
+                HttpResponseFixtures.createHttpResponse(999, null, "", false);
+
+        // x2 returns fro the above
+        when(mockHttpClient.execute(any(HttpPost.class)))
+                .thenReturn(initialRetryableCloseableHttpResponse)
+                .thenReturn(nonRetryableCloseableHttpResponse);
+
+        HttpRetryStatusConfig testHttpRetryStatusConfig =
+                HttpRetryStatusConfigFixtures.generateTestReplyStatusConfig(
+                        TEST_RETRY_STATUS_CODES, TEST_SUCCESS_STATUS_CODES);
+        httpRetryer.sendHTTPRequestRetryIfAllowed(mockPostRequest, testHttpRetryStatusConfig);
+
+        InOrder inOrderMockEventProbeSequence = inOrder(mockEventProbe);
+        inOrderMockEventProbeSequence
+                .verify(mockEventProbe, times(1))
+                .counterMetric(HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_RETRY_METRIC);
+
+        // Send Error
+        inOrderMockEventProbeSequence
+                .verify(mockEventProbe, times(1))
+                .counterMetric(HttpRetryStatusConfigFixtures.TEST_HTTP_RETRYER_SEND_ERROR_METRIC);
+
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockHttpClient, times(2)).execute(any(HttpPost.class));
+        verifyNoMoreInteractions(mockHttpClient);
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
@@ -4,13 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.di.ipv.cri.fraud.api.domain.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static uk.gov.di.ipv.cri.fraud.library.metrics.Definitions.*;
 
 @ExtendWith(MockitoExtension.class)
 class IdentityScoreCalculatorTest {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.*;
 class ServiceFactoryTest {
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private ConfigurationService mockConfigurationService;
-    @Mock private SSLContextFactory mockSslContextFactory;
     @Mock private ContraindicationMapper mockContraindicationMapper;
     @Mock private PersonIdentityValidator mockPersonIdentityValidator;
     @Mock private HttpClient mockHttpClient;
@@ -33,23 +32,22 @@ class ServiceFactoryTest {
             throws NoSuchAlgorithmException, InvalidKeyException {
         when(mockConfigurationService.getHmacKey()).thenReturn("hmac key");
         when(mockConfigurationService.getEndpointUrl()).thenReturn("https://test-endpoint");
+
         ServiceFactory serviceFactory =
                 new ServiceFactory(
                         mockObjectMapper,
                         mockEventProbe,
                         mockConfigurationService,
-                        mockSslContextFactory,
                         mockContraindicationMapper,
                         mockPersonIdentityValidator,
-                        mockHttpClient,
                         mockAuditService);
 
         IdentityVerificationService identityVerificationService =
                 serviceFactory.getIdentityVerificationService();
 
         assertNotNull(identityVerificationService);
-        verify(mockConfigurationService).getTenantId();
-        verify(mockConfigurationService).getHmacKey();
-        verify(mockConfigurationService).getEndpointUrl();
+        verify(mockConfigurationService, times(2)).getTenantId();
+        verify(mockConfigurationService, times(2)).getHmacKey();
+        verify(mockConfigurationService, times(2)).getEndpointUrl();
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReplyHelperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/HTTPReplyHelperTest.java
@@ -1,0 +1,72 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import org.apache.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.ipv.cri.fraud.api.util.HttpResponseFixtures.createHttpResponse;
+
+@ExtendWith(MockitoExtension.class)
+class HTTPReplyHelperTest {
+
+    private final String ENDPOINT_NAME = "Test Endpoint";
+    private final String NO_BODY_TEXT_FORMAT = "No %s response body text found";
+
+    @Test
+    void shouldRetrieveResult() throws OAuthErrorResponseException {
+
+        int expectedStatusCode = 200;
+        String expectedBodyContent = "Test Response Body";
+        String expectedTestHeaderKey = "X-TEST-HEADER";
+        String expectedTestHeaderValue = "test_value";
+
+        Map<String, String> expectedHeadersMap = new HashMap<>();
+        expectedHeadersMap.put(expectedTestHeaderKey, expectedTestHeaderValue);
+
+        HttpResponse mockResponse =
+                createHttpResponse(
+                        expectedStatusCode, expectedHeadersMap, expectedBodyContent, false);
+
+        HTTPReply reply = HTTPReplyHelper.retrieveResponse(mockResponse, ENDPOINT_NAME);
+
+        assertEquals(expectedBodyContent, reply.responseBody);
+        assertEquals(expectedStatusCode, reply.statusCode);
+        assertNotNull(reply.responseHeaders.get(expectedTestHeaderKey));
+        assertEquals(expectedTestHeaderValue, reply.responseHeaders.get(expectedTestHeaderKey));
+    }
+
+    @Test
+    void shouldSetNoBodyTextWhenEntityUtilsReturnsNull() throws OAuthErrorResponseException {
+
+        int expectedStatusCode = 200;
+        String expectedBodyContent = String.format(NO_BODY_TEXT_FORMAT, ENDPOINT_NAME);
+
+        HttpResponse mockResponse = createHttpResponse(expectedStatusCode, null, null, false);
+
+        HTTPReply reply = HTTPReplyHelper.retrieveResponse(mockResponse, ENDPOINT_NAME);
+
+        assertEquals(expectedBodyContent, reply.responseBody);
+        assertEquals(expectedStatusCode, reply.statusCode);
+    }
+
+    @Test
+    void shouldThrowOAuthHttpResponseExceptionWhenIOExceptionEncounteredRetrievingHTTPReply() {
+
+        HttpResponse mockResponse = createHttpResponse(200, null, null, true);
+
+        OAuthErrorResponseException thrownException =
+                assertThrows(
+                        OAuthErrorResponseException.class,
+                        () -> HTTPReplyHelper.retrieveResponse(mockResponse, ENDPOINT_NAME));
+
+        assertEquals("Failed to retrieve http response body", thrownException.getErrorReason());
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/SleepHelperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/SleepHelperTest.java
@@ -35,15 +35,6 @@ class SleepHelperTest {
         assertEquals(expectedWait, waitTime, EPSILON);
     }
 
-    @Test
-    void shouldSleep0msWhenCalledOnce() throws InterruptedException {
-        long expectedWait = 0;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(0);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
     void shouldBusyWait2P100ForCallN(int callNumber) {
@@ -58,34 +49,11 @@ class SleepHelperTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
-    void shouldSleep2P100ForCallN(int callNumber) throws InterruptedException {
-        long baseWaitTime = 100;
-        long power = callNumber - 1;
-
-        long expectedWait = (long) Math.pow(2, power) * baseWaitTime;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(callNumber);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
-    @ParameterizedTest
     @ValueSource(ints = {8, 9})
     void shouldBusyWaitMaxTimeWhenCalledMoreThan7Times(int callNumber) {
         long expectedWait = MAX_TEST_SLEEP;
 
         long waitTime = sleepHelper.busyWaitWithExponentialBackOff(callNumber);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {8, 9})
-    void shouldSleepMaxTimeWhenCalledMoreThan7Times(int callNumber) throws InterruptedException {
-        long expectedWait = MAX_TEST_SLEEP;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(callNumber);
 
         assertEquals(expectedWait, waitTime, EPSILON);
     }

--- a/lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/HttpResponseFixtures.java
+++ b/lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/HttpResponseFixtures.java
@@ -1,0 +1,268 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.params.HttpParams;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class HttpResponseFixtures {
+    private HttpResponseFixtures() {
+        throw new IllegalStateException("Test Fixtures");
+    }
+
+    // Used to create response scenarios in unit tests
+    public static CloseableHttpResponse createHttpResponse(
+            int statusCode, Map<String, String> headers, String responseBody, boolean ioException) {
+        return new CloseableHttpResponse() {
+
+            @Override
+            public ProtocolVersion getProtocolVersion() {
+                return null;
+            }
+
+            @Override
+            public boolean containsHeader(String name) {
+                return false;
+            }
+
+            @Override
+            public Header[] getHeaders(String name) {
+                return new Header[0];
+            }
+
+            @Override
+            public Header getFirstHeader(String name) {
+                return null;
+            }
+
+            @Override
+            public Header getLastHeader(String name) {
+                return null;
+            }
+
+            @Override
+            public Header[] getAllHeaders() {
+                Header[] apacheHeaders;
+
+                if (headers != null) {
+                    int numHeaders = headers.size();
+
+                    apacheHeaders = new Header[numHeaders];
+
+                    List<String> keys = new ArrayList<>(headers.keySet());
+
+                    for (int h = 0; h < numHeaders; h++) {
+
+                        String key = keys.get(0);
+                        String value = headers.get(key);
+
+                        apacheHeaders[h] = new BasicHeader(key, value);
+                    }
+                } else {
+                    apacheHeaders = new Header[0];
+                }
+
+                return apacheHeaders;
+            }
+
+            @Override
+            public void addHeader(Header header) {
+                // Test Fixture
+            }
+
+            @Override
+            public void addHeader(String name, String value) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setHeader(Header header) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setHeader(String name, String value) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setHeaders(Header[] headers) {
+                // Test Fixture
+            }
+
+            @Override
+            public void removeHeader(Header header) {
+                // Test Fixture
+            }
+
+            @Override
+            public void removeHeaders(String name) {
+                // Test Fixture
+            }
+
+            @Override
+            public HeaderIterator headerIterator() {
+                return null;
+            }
+
+            @Override
+            public HeaderIterator headerIterator(String name) {
+                return null;
+            }
+
+            @Override
+            public HttpParams getParams() {
+                return null;
+            }
+
+            @Override
+            public void setParams(HttpParams params) {
+                // Test Fixture
+            }
+
+            @Override
+            public StatusLine getStatusLine() {
+                return new StatusLine() {
+                    @Override
+                    public ProtocolVersion getProtocolVersion() {
+                        return null;
+                    }
+
+                    @Override
+                    public int getStatusCode() {
+                        return statusCode;
+                    }
+
+                    @Override
+                    public String getReasonPhrase() {
+                        return "OK";
+                    }
+                };
+            }
+
+            @Override
+            public void setStatusLine(StatusLine statusline) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setStatusLine(ProtocolVersion ver, int code) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setStatusLine(ProtocolVersion ver, int code, String reason) {
+                // Test Fixture
+            }
+
+            @Override
+            public void setStatusCode(int code) throws IllegalStateException {
+                // Test Fixture
+            }
+
+            @Override
+            public void setReasonPhrase(String reason) throws IllegalStateException {
+                // Test Fixture
+            }
+
+            @Override
+            public HttpEntity getEntity() {
+
+                ByteArrayInputStream bai = null;
+                long contentLength = 0;
+                if (responseBody != null) {
+                    contentLength = responseBody.getBytes().length;
+                    bai = new ByteArrayInputStream(responseBody.getBytes());
+                }
+
+                final long finalContentLength = contentLength;
+                final ByteArrayInputStream finalBai = bai;
+
+                return new HttpEntity() {
+                    @Override
+                    public boolean isRepeatable() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isChunked() {
+                        return false;
+                    }
+
+                    @Override
+                    public long getContentLength() {
+                        return finalContentLength;
+                    }
+
+                    @Override
+                    public Header getContentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public Header getContentEncoding() {
+                        return null;
+                    }
+
+                    @Override
+                    public InputStream getContent() throws IOException {
+
+                        if (!ioException) {
+                            return finalBai;
+                        }
+
+                        throw new IOException("ERROR!");
+                    }
+
+                    @Override
+                    public void writeTo(OutputStream outStream) throws IOException {
+                        // Test Fixture
+                    }
+
+                    @Override
+                    public boolean isStreaming() {
+                        return false;
+                    }
+
+                    @Override
+                    public void consumeContent() throws IOException {
+                        // Test Fixture
+                    }
+                };
+            }
+
+            @Override
+            public void setEntity(HttpEntity entity) {
+                // Test Fixture
+            }
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public void setLocale(Locale loc) {
+                // Test Fixture
+            }
+
+            @Override
+            public void close() throws IOException {
+                // Test Fixture
+            }
+        };
+    }
+}

--- a/lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/HttpRetryStatusConfigFixtures.java
+++ b/lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/HttpRetryStatusConfigFixtures.java
@@ -1,0 +1,62 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryStatusConfig;
+
+import java.util.List;
+
+public class HttpRetryStatusConfigFixtures {
+    private HttpRetryStatusConfigFixtures() {
+        throw new IllegalStateException("Test Fixtures");
+    }
+
+    public static final String TEST_HTTP_RETRYER_SEND_OK_METRIC =
+            "test_http_retryer_send_ok_metric";
+    public static final String TEST_HTTP_RETRYER_SEND_FAIL_METRIC =
+            "test_http_retryer_send_fail_metric";
+    public static final String TEST_HTTP_RETRYER_SEND_ERROR_METRIC =
+            "test_http_retryer_send_error_metric";
+    public static final String TEST_HTTP_RETRYER_SEND_RETRY_METRIC =
+            "test_http_retryer_send_retry_metric";
+    public static final String TEST_HTTP_RETRYER_SEND_MAX_RETRIES_METRIC =
+            "test_http_retryer_send_max_retries_metric";
+
+    public static HttpRetryStatusConfig generateTestReplyStatusConfig(
+            List<Integer> retryStatusCodes, List<Integer> successStatusCodes) {
+        return new HttpRetryStatusConfig() {
+            @Override
+            public boolean shouldHttpClientRetry(int statusCode) {
+                return retryStatusCodes.contains(statusCode);
+            }
+
+            @Override
+            public boolean isSuccessStatusCode(int statusCode) {
+                return successStatusCodes.contains(statusCode);
+            }
+
+            @Override
+            public String httpRetryerSendOkMetric() {
+                return TEST_HTTP_RETRYER_SEND_OK_METRIC;
+            }
+
+            @Override
+            public String httpRetryerSendFailMetric(Exception e) {
+                return TEST_HTTP_RETRYER_SEND_FAIL_METRIC;
+            }
+
+            @Override
+            public String httpRetryerSendErrorMetric() {
+                return TEST_HTTP_RETRYER_SEND_ERROR_METRIC;
+            }
+
+            @Override
+            public String httpRetryerSendRetryMetric() {
+                return TEST_HTTP_RETRYER_SEND_RETRY_METRIC;
+            }
+
+            @Override
+            public String httpRetryerMaxRetriesMetric() {
+                return TEST_HTTP_RETRYER_SEND_MAX_RETRIES_METRIC;
+            }
+        };
+    }
+}

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id "java"
 	id "jacoco"
-	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
+	id "io.freefair.aspectj.post-compile-weaving" version "6.6.3"
 }
 
 dependencies {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,13 +1,14 @@
 plugins {
 	id "java-library"
 	id "jacoco"
-	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
+	id "io.freefair.aspectj.post-compile-weaving" version "6.6.3"
 }
 
 dependencies {
 
 	implementation configurations.cri_common_lib,
 			configurations.aws,
+			configurations.aws_apache_http_client,
 			configurations.dynamodb
 
 	aspect configurations.powertools

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/config/HttpRequestConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/config/HttpRequestConfig.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.cri.fraud.library.config;
+
+import lombok.experimental.UtilityClass;
+import org.apache.http.client.config.RequestConfig;
+
+@UtilityClass
+public class HttpRequestConfig {
+    public static RequestConfig getCustomRequestConfig(
+            int poolRequestTimeout, int initialConnectionTimeout, int socketReadTimeout) {
+        return RequestConfig.custom()
+                .setConnectionRequestTimeout(poolRequestTimeout)
+                .setConnectTimeout(initialConnectionTimeout)
+                .setSocketTimeout(socketReadTimeout)
+                .build();
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
@@ -1,0 +1,49 @@
+package uk.gov.di.ipv.cri.fraud.library.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ErrorResponse {
+    FAILED_TO_PARSE_DRIVING_PERMIT_FORM_DATA(1000, "Failed to parse Driving Permit form data"),
+    FORM_DATA_FAILED_VALIDATION(1001, "Form Data failed validation"),
+    TOO_MANY_RETRY_ATTEMPTS(1002, "Too many retry attempts made"),
+
+    FAILED_TO_RETRIEVE_HTTP_RESPONSE_BODY(1099, "Failed to retrieve http response body"),
+
+    /**************************************Fraud Check Specific Errors************************************/
+
+    FAILED_TO_CREATE_API_REQUEST_FOR_FRAUD_CHECK(
+            2001, "Failed to create API Request for Fraud Check"),
+    ERROR_SENDING_FRAUD_CHECK_REQUEST(2002, "error sending Fraud check request"),
+    FAILED_TO_MAP_FRAUD_CHECK_RESPONSE_BODY(2003, "failed to map Fraud check response_body"),
+    ERROR_FRAUD_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE(
+            2004, "error Fraud check returned unexpected http status code"),
+    /**************************************PEP Check Specific Errors************************************/
+
+    FAILED_TO_CREATE_API_REQUEST_FOR_PEP_CHECK(3001, "Failed to create API Request for PEP Check"),
+    ERROR_SENDING_PEP_CHECK_REQUEST(3002, "error sending PEP check request"),
+    FAILED_TO_MAP_PEP_CHECK_RESPONSE_BODY(3003, "failed to map PEP check response_body"),
+    ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE(
+            3004, "error PEP check returned unexpected http status code"),
+
+    FINAL_ERROR(-1, "Final Error");
+
+    private final int code;
+    private final String message;
+
+    ErrorResponse(
+            @JsonProperty(required = true, value = "code") int code,
+            @JsonProperty(required = true, value = "message") String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/exception/MetricException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/exception/MetricException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.cri.fraud.library.exception;
+
+public class MetricException extends RuntimeException {
+    public MetricException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/exception/OAuthErrorResponseException.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/exception/OAuthErrorResponseException.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.fraud.library.exception;
+
+import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
+
+public class OAuthErrorResponseException extends Exception {
+    private final int statusCode;
+    private final ErrorResponse errorResponse;
+
+    public OAuthErrorResponseException(int statusCode, ErrorResponse errorResponse) {
+        this.statusCode = statusCode;
+        this.errorResponse = errorResponse;
+    }
+
+    public String getErrorReason() {
+        return this.errorResponse.getMessage();
+    }
+
+    public int getStatusCode() {
+        return this.statusCode;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        return this.errorResponse;
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/Definitions.java
@@ -1,14 +1,6 @@
 package uk.gov.di.ipv.cri.fraud.library.metrics;
 
 public class Definitions {
-
-    // TODO Remove these first two metrics when safe
-    //  - Kept until alerts are converted to the _completed metrics
-    // They are named incorrectly, inconsistently placed and called.
-    // The LAMBDA_NAME_COMPLETED metrics are the replacements
-    public static final String TODO_REMOVE_BK_COMPAT_M1 = "fraud_issue_credential";
-    public static final String TODO_REMOVE_BK_COMPAT_M2 = "fraud_credential_issuer";
-
     // These completed metrics record all escape routes from the lambdas.
     // OK for expected routes with ERROR being all others
     public static final String LAMBDA_IDENTITY_CHECK_COMPLETED_OK =
@@ -38,16 +30,6 @@ public class Definitions {
     // Per response Contra Indicators (CI is Appended)
     public static final String FRAUD_CHECK_CI_PREFIX = "fraud_check_ci_";
     public static final String PEP_CHECK_CI_PREFIX = "pep_check_ci_";
-
-    // HTTP Connection Send (Both)
-    public static final String THIRD_PARTY_REQUEST_CREATED = "third_party_requests_created";
-    public static final String THIRD_PARTY_REQUEST_SEND_RETRY = "third_party_requests_send_retry";
-    public static final String THIRD_PARTY_REQUEST_SEND_OK = "third_party_request_send_ok";
-    public static final String THIRD_PARTY_REQUEST_SEND_ERROR = "third_party_request_send_error";
-    public static final String THIRD_PARTY_REQUEST_SEND_MAX_RETRIES =
-            "third_party_request_send_max_retries";
-    public static final String THIRD_PARTY_REQUEST_SEND_FAIL =
-            "third_party_requests_send_fail"; // IOException
 
     // Third Party Response Type Fraud
     public static final String THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetric.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetric.java
@@ -1,0 +1,115 @@
+package uk.gov.di.ipv.cri.fraud.library.metrics;
+
+import uk.gov.di.ipv.cri.fraud.library.exception.MetricException;
+import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
+
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.API_RESPONSE_TYPE_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.API_RESPONSE_TYPE_EXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.API_RESPONSE_TYPE_INVALID;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.API_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.API_RESPONSE_TYPE_VALID;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.HTTP_RETRYER_REQUEST_SEND_FAIL;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.HTTP_RETRYER_REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.HTTP_RETRYER_REQUEST_SEND_RETRY;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.HTTP_RETRYER_SEND_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.HTTP_RETRYER_SEND_MAX_RETRIES;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.REQUEST_CREATED;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.REQUEST_SEND_ERROR;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIEndpointMetricType.REQUEST_SEND_OK;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIMetricEndpointPrefix.FRAUD_V1;
+import static uk.gov.di.ipv.cri.fraud.library.metrics.ThirdPartyAPIMetricEndpointPrefix.PEP_V1;
+
+public enum ThirdPartyAPIEndpointMetric {
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // FRAUD End Point Metrics                                                                   //
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    FRAUD_REQUEST_CREATED(FRAUD_V1, REQUEST_CREATED),
+    FRAUD_REQUEST_SEND_OK(FRAUD_V1, REQUEST_SEND_OK),
+    FRAUD_REQUEST_SEND_ERROR(FRAUD_V1, REQUEST_SEND_ERROR),
+
+    FRAUD_RESPONSE_TYPE_VALID(FRAUD_V1, API_RESPONSE_TYPE_VALID),
+    FRAUD_RESPONSE_TYPE_INVALID(FRAUD_V1, API_RESPONSE_TYPE_INVALID),
+
+    FRAUD_RESPONSE_TYPE_ERROR(FRAUD_V1, API_RESPONSE_TYPE_ERROR),
+
+    FRAUD_RESPONSE_TYPE_EXPECTED_HTTP_STATUS(FRAUD_V1, API_RESPONSE_TYPE_EXPECTED_HTTP_STATUS),
+    FRAUD_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS(FRAUD_V1, API_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS),
+
+    FRAUD_HTTP_RETRYER_REQUEST_SEND_OK(FRAUD_V1, HTTP_RETRYER_REQUEST_SEND_OK),
+    FRAUD_HTTP_RETRYER_REQUEST_SEND_FAIL(FRAUD_V1, HTTP_RETRYER_REQUEST_SEND_FAIL),
+    FRAUD_HTTP_RETRYER_REQUEST_SEND_RETRY(FRAUD_V1, HTTP_RETRYER_REQUEST_SEND_RETRY),
+    FRAUD_HTTP_RETRYER_SEND_MAX_RETRIES(FRAUD_V1, HTTP_RETRYER_SEND_MAX_RETRIES),
+    FRAUD_HTTP_RETRYER_SEND_ERROR(FRAUD_V1, HTTP_RETRYER_SEND_ERROR),
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // PEP End Point Metrics                                                                   //
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    PEP_REQUEST_CREATED(PEP_V1, REQUEST_CREATED),
+    PEP_REQUEST_SEND_OK(PEP_V1, REQUEST_SEND_OK),
+    PEP_REQUEST_SEND_ERROR(PEP_V1, REQUEST_SEND_ERROR),
+
+    PEP_RESPONSE_TYPE_VALID(PEP_V1, API_RESPONSE_TYPE_VALID),
+    PEP_RESPONSE_TYPE_INVALID(PEP_V1, API_RESPONSE_TYPE_INVALID),
+
+    PEP_RESPONSE_TYPE_ERROR(PEP_V1, API_RESPONSE_TYPE_ERROR),
+
+    PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS(PEP_V1, API_RESPONSE_TYPE_EXPECTED_HTTP_STATUS),
+    PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS(PEP_V1, API_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS),
+
+    PEP_HTTP_RETRYER_REQUEST_SEND_OK(PEP_V1, HTTP_RETRYER_REQUEST_SEND_OK),
+    PEP_HTTP_RETRYER_REQUEST_SEND_FAIL(PEP_V1, HTTP_RETRYER_REQUEST_SEND_FAIL),
+    PEP_HTTP_RETRYER_REQUEST_SEND_RETRY(PEP_V1, HTTP_RETRYER_REQUEST_SEND_RETRY),
+    PEP_HTTP_RETRYER_SEND_MAX_RETRIES(PEP_V1, HTTP_RETRYER_SEND_MAX_RETRIES),
+    PEP_HTTP_RETRYER_SEND_ERROR(PEP_V1, HTTP_RETRYER_SEND_ERROR);
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // End Of Metric Descriptions                                                                //
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    private static final String METRIC_FORMAT = "%s_%s";
+    private static final String METRIC_CAUSE_FORMAT = METRIC_FORMAT;
+
+    private final String metricWithEndpointPrefix;
+
+    // To avoid copy and paste errors in the alternative large list of string mappings for each
+    // endpoint metric combo
+    ThirdPartyAPIEndpointMetric(
+            ThirdPartyAPIMetricEndpointPrefix prefix, ThirdPartyAPIEndpointMetricType metricType) {
+        String endPointPrefixLowerCase = prefix.toString().toLowerCase();
+        String metricTypeLowercase = metricType.toString().toLowerCase();
+        this.metricWithEndpointPrefix =
+                String.format(METRIC_FORMAT, endPointPrefixLowerCase, metricTypeLowercase);
+    }
+
+    // To allow special case metrics that do not apply to all endpoints (eg UP/DOWN health)
+    ThirdPartyAPIEndpointMetric(ThirdPartyAPIMetricEndpointPrefix prefix, String metric) {
+        String endPointPrefixLowerCase = prefix.toString().toLowerCase();
+        String metricLowercase = metric.toLowerCase();
+        this.metricWithEndpointPrefix =
+                String.format(METRIC_FORMAT, endPointPrefixLowerCase, metricLowercase);
+    }
+
+    public String withEndpointPrefix() {
+        return metricWithEndpointPrefix;
+    }
+
+    /**
+     * Created for attaching Exception to REQUEST_SEND_ERROR - format effectively - %s_%s_%s. NOTE:
+     * invalid to provide OAuthErrorResponseException. OAuthErrorResponseException is a generated
+     * exception, metrics should only capture caught executions.
+     *
+     * @return String in the format endpont_metric_exceptionname
+     */
+    public String withEndpointPrefixAndExceptionName(Exception e) {
+        if (e instanceof OAuthErrorResponseException) {
+            // OAuthErrorResponseException is a generated exception,
+            // metrics should only capture caught executions
+            throw new MetricException(
+                    "OAuthErrorResponseException is not a valid exception for metrics");
+        }
+
+        return String.format(
+                METRIC_CAUSE_FORMAT, metricWithEndpointPrefix, e.getClass().getSimpleName());
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetricType.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetricType.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.cri.fraud.library.metrics;
+
+/** Not for direct use - see {@link ThirdPartyAPIEndpointMetric} */
+public enum ThirdPartyAPIEndpointMetricType {
+    REQUEST_CREATED,
+    REQUEST_SEND_OK,
+    REQUEST_SEND_ERROR,
+    API_RESPONSE_TYPE_VALID,
+    API_RESPONSE_TYPE_INVALID,
+    API_RESPONSE_TYPE_ERROR,
+    API_RESPONSE_TYPE_EXPECTED_HTTP_STATUS,
+    API_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS,
+    // HTTP HttpRetryer see @HttpRetryStatusConfig
+    HTTP_RETRYER_REQUEST_SEND_OK,
+    HTTP_RETRYER_REQUEST_SEND_FAIL,
+    HTTP_RETRYER_REQUEST_SEND_RETRY,
+    HTTP_RETRYER_SEND_MAX_RETRIES,
+    HTTP_RETRYER_SEND_ERROR;
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIMetricEndpointPrefix.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIMetricEndpointPrefix.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.cri.fraud.library.metrics;
+
+/** Not for direct use - see {@link ThirdPartyAPIEndpointMetric} */
+public enum ThirdPartyAPIMetricEndpointPrefix {
+    // Only one endpoint on DCS API
+    FRAUD_V1,
+    PEP_V1
+}

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## Proposed changes

### What changed

Switch FraudAPI HTTPClient to Apache 4.5 HttpClient provided by the AWS SDK 2 for Java.
Align http response handling with DL/Passport CRI's.

### Why did it change

To remove limitation of being unable to timeout http requests

### Issue tracking

- [LIME-889](https://govukverify.atlassian.net/browse/LIME-889)

[LIME-889]: https://govukverify.atlassian.net/browse/LIME-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ