### PR TITLE
LIME-889 Add missing SSL context configuration

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.http.HttpException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,7 +32,6 @@ import uk.gov.di.ipv.cri.fraud.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.fraud.api.util.FraudPersonIdentityDetailedMapper;
 import uk.gov.di.ipv.cri.fraud.library.persistence.item.FraudResultItem;
 
-import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -53,7 +53,7 @@ public class FraudHandler
     private final ConfigurationService configurationService;
     private final AuditService auditService;
 
-    public FraudHandler() throws NoSuchAlgorithmException, IOException, InvalidKeyException {
+    public FraudHandler() throws NoSuchAlgorithmException, InvalidKeyException, HttpException {
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         ServiceFactory serviceFactory = new ServiceFactory(objectMapper);
         this.eventProbe = new EventProbe();

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,12 +9,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.http.HttpClient;
 import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Base64;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceFactoryTest {
@@ -29,9 +39,18 @@ class ServiceFactoryTest {
 
     @Test
     void shouldCreateIdentityVerificationService()
-            throws NoSuchAlgorithmException, InvalidKeyException {
+            throws NoSuchAlgorithmException, InvalidKeyException, HttpException, KeyStoreException,
+                    CertificateException, IOException {
         when(mockConfigurationService.getHmacKey()).thenReturn("hmac key");
         when(mockConfigurationService.getEndpointUrl()).thenReturn("https://test-endpoint");
+
+        // Test needs a real keystore as it is auto mapped from strings
+        final char[] unitTestKeyStorePassword = UUID.randomUUID().toString().toCharArray();
+        String testKeyStore = generateUnitTestKeyStore(unitTestKeyStorePassword);
+        String testKeyStorePassword = new String(unitTestKeyStorePassword);
+
+        when(mockConfigurationService.getEncodedKeyStore()).thenReturn(testKeyStore);
+        when(mockConfigurationService.getKeyStorePassword()).thenReturn(testKeyStorePassword);
 
         ServiceFactory serviceFactory =
                 new ServiceFactory(
@@ -49,5 +68,19 @@ class ServiceFactoryTest {
         verify(mockConfigurationService, times(2)).getTenantId();
         verify(mockConfigurationService, times(2)).getHmacKey();
         verify(mockConfigurationService, times(2)).getEndpointUrl();
+    }
+
+    private String generateUnitTestKeyStore(char[] unitTestKeyStorePassword)
+            throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+
+        KeyStore unitTestkeyStore = KeyStore.getInstance("pkcs12");
+        unitTestkeyStore.load(null, unitTestKeyStorePassword); // New KeyStore
+
+        ByteArrayOutputStream bao = new ByteArrayOutputStream();
+        unitTestkeyStore.store(bao, unitTestKeyStorePassword);
+
+        byte[] base64 = Base64.getEncoder().encode(bao.toByteArray());
+
+        return new String(base64);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Add custom SSL context to the apache http client 

### Why did it change

Custom SSL configuration was incorrectly assumed not to be needed.

### Issue tracking

- [LIME-889](https://govukverify.atlassian.net/browse/LIME-889)


[LIME-889]: https://govukverify.atlassian.net/browse/LIME-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ