### PR TITLE
LIME-912 Add CrosscoreV2 feature toggle

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -204,6 +204,14 @@ Mappings:
       integration: "https://review-f.integration.account.gov.uk"
       production: "https://review-f.account.gov.uk"
 
+  FraudCriCrosscoreV2EnabledMapping:
+    Environment:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
   FraudCriPepEnabledMapping:
     Environment:
       dev: "true"
@@ -474,6 +482,7 @@ Resources:
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/noFileFoundThreshold"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/FraudTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/CrosscoreV2/enabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pepEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
@@ -701,6 +710,14 @@ Resources:
       Type: String
       Value: !FindInMap [FraudCriAudienceMapping, Environment, !Ref 'Environment']
       Description: The fraud credential issuer (audience) identifier
+
+  FraudCriUseCrosscoreV2EnabledParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/CrosscoreV2/enabled"
+      Type: String
+      Value: !FindInMap [ FraudCriCrosscoreV2EnabledMapping, Environment, !Ref 'Environment' ]
+      Description: CrosscoreV2 enabled feature toggle
 
   FraudCriPepEnabledParameter:
     Type: AWS::SSM::Parameter

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
@@ -50,7 +50,10 @@ public class FraudCheckConfigurationService {
     private final String parameterPrefix;
     private final String stackParameterPrefix;
     private final String commonParameterPrefix;
+
+    private final boolean crosscoreV2Enabled;
     private final boolean pepEnabled;
+
     private List<String> zeroScoreUcodes;
     private Integer noFileFoundThreshold;
     private final long fraudResultItemTtl;
@@ -93,6 +96,9 @@ public class FraudCheckConfigurationService {
                 Long.parseLong(paramProvider.get(getCommonParameterName("SessionTtl")));
 
         // *****************************Feature Toggles*******************************
+
+        this.crosscoreV2Enabled =
+                Boolean.valueOf(paramProvider.get(getStackParameterName("CrosscoreV2/enabled")));
 
         this.pepEnabled = Boolean.valueOf(paramProvider.get(getStackParameterName("pepEnabled")));
 
@@ -139,6 +145,10 @@ public class FraudCheckConfigurationService {
 
     public String getContraindicationMappings() {
         return contraindicationMappings;
+    }
+
+    public boolean crosscoreV2Enabled() {
+        return crosscoreV2Enabled;
     }
 
     public boolean getPepEnabled() {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
@@ -6,8 +6,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.lambda.powertools.parameters.ParamProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,60 +21,146 @@ import static org.mockito.Mockito.when;
 import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 @ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
 class FraudCheckConfigurationServiceTest {
     private static final String KEY_FORMAT = "/%s/credentialIssuers/fraud/%s";
+
+    private static final String STACK_PARAMETER_FORMAT = "/%s/%s";
+
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    private final String ENVIRONMENT = "dev"; // env used for older ccv1 secrets manager parameters
+    private final String AWS_STACK_NAME = "fraud-api-dev";
+    private final String PARAMETER_PREFIX = AWS_STACK_NAME;
+    private final String COMMON_PARAMETER_NAME_PREFIX = "common-cri-api";
+
     @Mock private SecretsProvider mockSecretsProvider;
     @Mock private ParamProvider mockParamProvider;
 
     @Test
     void shouldInitialiseConfigFieldsWhenValidInputProvided() {
-        String env = "dev";
+        environmentVariables.set("ENVIRONMENT", ENVIRONMENT);
+        environmentVariables.set("AWS_REGION", "eu-west-2");
+        environmentVariables.set("PARAMETER_PREFIX", PARAMETER_PREFIX);
+        environmentVariables.set("AWS_STACK_NAME", AWS_STACK_NAME);
+        environmentVariables.set("COMMON_PARAMETER_NAME_PREFIX", COMMON_PARAMETER_NAME_PREFIX);
 
         String tenantIdKey = "thirdPartyApiTenantId";
         String tenantIdValue = "test-tenant-id";
+
         String hmacKey = "thirdPartyApiHmacKey";
         String testHmacKeyValue = "test-key";
+
         String endpointKey = "thirdPartyApiEndpointUrl";
         String endpointValue = "test-endpoint";
+
         String thirdPartyIdKey = "thirdPartyId";
         String thirdPartyIdValue = "third-party-id";
+
         String keyStoreKey = "thirdPartyApiKeyStore";
+
+        String fraudTableNameKey = "FraudTableName";
+        String fraudTableNameValue = "FraudTableValue";
+
+        String contraindicationMappingsKey = "contraindicationMappings";
+        String contraindicationMappingsValue = "null:null";
+
+        String zeroScoreUcodesKey = "zeroScoreUcodes";
+        String zeroScoreUcodesValue = "U001,U002";
+        List<String> zeroScoreUcodesListValue = List.of(zeroScoreUcodesValue.split(","));
+
+        String noFileFoundThresholdKey = "noFileFoundThreshold";
+        Integer noFileFoundThresholdValue = 35;
+
+        String sessionTtlKey = "SessionTtl";
+        long sessionTtlValue = 7200L;
+
+        String crosscoreV2Enabled = "CrosscoreV2/enabled";
+        boolean crosscoreV2EnabledValue = false;
 
         FraudCheckConfigurationService.KeyStoreParams testKeyStoreParams =
                 new FraudCheckConfigurationService.KeyStoreParams();
         testKeyStoreParams.setKeyStore("keystore");
         testKeyStoreParams.setKeyStorePassword("pwd");
 
-        when(mockParamProvider.get(String.format(KEY_FORMAT, env, tenantIdKey)))
+        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, tenantIdKey)))
                 .thenReturn(tenantIdValue);
-        when(mockParamProvider.get(String.format(KEY_FORMAT, env, endpointKey)))
+        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, endpointKey)))
                 .thenReturn(endpointValue);
-        when(mockParamProvider.get(String.format(KEY_FORMAT, env, thirdPartyIdKey)))
+        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, thirdPartyIdKey)))
                 .thenReturn(thirdPartyIdValue);
-        when(mockParamProvider.get("/null/FraudTableName")).thenReturn("None");
-        when(mockParamProvider.get("/null/contraindicationMappings")).thenReturn("null:null");
-        when(mockParamProvider.get("/null/zeroScoreUcodes")).thenReturn("U001,U002");
-        when(mockParamProvider.get("/null/noFileFoundThreshold")).thenReturn("35");
-        when(mockParamProvider.get("/null/SessionTtl")).thenReturn("7200");
-        when(mockSecretsProvider.get(String.format(KEY_FORMAT, env, hmacKey)))
+
+        when(mockParamProvider.get(
+                        String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, fraudTableNameKey)))
+                .thenReturn(fraudTableNameValue);
+        when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT,
+                                AWS_STACK_NAME,
+                                contraindicationMappingsKey)))
+                .thenReturn(contraindicationMappingsValue);
+        when(mockParamProvider.get(
+                        String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, zeroScoreUcodesKey)))
+                .thenReturn(zeroScoreUcodesValue);
+        when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, noFileFoundThresholdKey)))
+                .thenReturn(String.valueOf(noFileFoundThresholdValue));
+        when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT,
+                                COMMON_PARAMETER_NAME_PREFIX,
+                                sessionTtlKey)))
+                .thenReturn(String.valueOf(sessionTtlValue));
+
+        when(mockParamProvider.get(
+                        String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2Enabled)))
+                .thenReturn(String.valueOf(crosscoreV2EnabledValue));
+
+        when(mockSecretsProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, hmacKey)))
                 .thenReturn(testHmacKeyValue);
         when(mockSecretsProvider.get(
-                        String.format(KEY_FORMAT, env, keyStoreKey),
+                        String.format(KEY_FORMAT, ENVIRONMENT, keyStoreKey),
                         FraudCheckConfigurationService.KeyStoreParams.class))
                 .thenReturn(testKeyStoreParams);
         when(mockSecretsProvider.withTransformation(json)).thenReturn(mockSecretsProvider);
 
         FraudCheckConfigurationService fraudCheckConfigurationService =
-                new FraudCheckConfigurationService(mockSecretsProvider, mockParamProvider, env);
+                new FraudCheckConfigurationService(
+                        mockSecretsProvider, mockParamProvider, ENVIRONMENT);
 
         assertNotNull(fraudCheckConfigurationService);
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, env, tenantIdKey));
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, env, endpointKey));
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, env, thirdPartyIdKey));
-        verify(mockSecretsProvider).get(String.format(KEY_FORMAT, env, hmacKey));
+        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, tenantIdKey));
+        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, endpointKey));
+        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, thirdPartyIdKey));
+        verify(mockSecretsProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, hmacKey));
+
+        verify(mockParamProvider)
+                .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, fraudTableNameKey));
+        verify(mockParamProvider)
+                .get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT,
+                                AWS_STACK_NAME,
+                                contraindicationMappingsKey));
+        verify(mockParamProvider)
+                .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, zeroScoreUcodesKey));
+        verify(mockParamProvider)
+                .get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, noFileFoundThresholdKey));
+        verify(mockParamProvider)
+                .get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT,
+                                COMMON_PARAMETER_NAME_PREFIX,
+                                sessionTtlKey));
+
+        verify(mockParamProvider)
+                .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2Enabled));
+
         verify(mockSecretsProvider)
                 .get(
-                        String.format(KEY_FORMAT, env, keyStoreKey),
+                        String.format(KEY_FORMAT, ENVIRONMENT, keyStoreKey),
                         FraudCheckConfigurationService.KeyStoreParams.class);
         assertEquals(
                 testKeyStoreParams.getKeyStore(),
@@ -82,6 +172,18 @@ class FraudCheckConfigurationServiceTest {
         assertEquals(thirdPartyIdValue, fraudCheckConfigurationService.getThirdPartyId());
         assertEquals(endpointValue, fraudCheckConfigurationService.getEndpointUrl());
         assertEquals(tenantIdValue, fraudCheckConfigurationService.getTenantId());
+
+        assertEquals(fraudTableNameValue, fraudCheckConfigurationService.getFraudResultTableName());
+        assertEquals(
+                contraindicationMappingsValue,
+                fraudCheckConfigurationService.getContraindicationMappings());
+        assertEquals(zeroScoreUcodesListValue, fraudCheckConfigurationService.getZeroScoreUcodes());
+        assertEquals(
+                noFileFoundThresholdValue,
+                fraudCheckConfigurationService.getNoFileFoundThreshold());
+        assertEquals(sessionTtlValue, fraudCheckConfigurationService.getFraudResultItemTtl());
+
+        assertEquals(crosscoreV2EnabledValue, fraudCheckConfigurationService.crosscoreV2Enabled());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Add CrosscoreV2 feature toggle

Improve coverage in FraudCheckConfigurationService

### Why did it change

CrosscoreV2 feature toggle to control enablement.

FraudCheckConfigurationService was missing several asserts on ssm values.
Add assert for useCrosscoreV2.

### Issue tracking

- [LIME-912](https://govukverify.atlassian.net/browse/LIME-912)


[LIME-912]: https://govukverify.atlassian.net/browse/LIME-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ