### PR TITLE
Lime 990 - upgrade aws embedded metrics from v1.0.6 to v2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
 		aws_sdk_version                    : "2.21.9",
 		aws_lambda_core_version            : "1.2.1",
 		aws_lambda_events_version          : "3.11.3",
+		aws_embedded_metrics_version       : "2.0.0",
 		jackson_version                    : "2.15.0",
 		gson_version                       : "2.8.9",
 		httpcomponents_core_version        : "4.4.16",

--- a/lambdas/fraudcheck/build.gradle
+++ b/lambdas/fraudcheck/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}",
 			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
 			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
+			"software.amazon.cloudwatchlogs:aws-embedded-metrics:${dependencyVersions.aws_embedded_metrics_version}",
 			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
 			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
 			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 			"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}",
 			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
 			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
+			"software.amazon.cloudwatchlogs:aws-embedded-metrics:${dependencyVersions.aws_embedded_metrics_version}",
 			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
 			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
 			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",


### PR DESCRIPTION
## Proposed changes

### What changed

Upgrade aws embedded metrics to 2.0.0 

### Why did it change

4.0+ cannot be used with-out code changes in CRI lib.
2.0 is code compatible and includes a tcp client change that may resolve the Socket closed exception logged by software.amazon.cloudwatchlogs.emf.sinks.TCPClient and subsequent failure of metrics to be captured by that lambda instance.

### Issue tracking

- [LIME-990](https://govukverify.atlassian.net/browse/LIME-990)


[LIME-990]: https://govukverify.atlassian.net/browse/LIME-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ