### PR TITLE
LIME-951 - Creating Call to crosscoreV2

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Run Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --parallel test jacocoTestReport -x spotlessApply -x spotlessCheck
+        run: ./gradlew --parallel test report jacocoTestReport -x spotlessApply -x spotlessCheck
       - name: Upload Unit Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -125,8 +125,6 @@ jobs:
           path: |
             */build/jacoco/
             */build/reports/
-      - name: Generate Aggregate Coverage Report
-        run: ./gradlew report
       - name: Run SonarCloud Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -125,6 +125,8 @@ jobs:
           path: |
             */build/jacoco/
             */build/reports/
+      - name: Generate Aggregate Coverage Report
+        run: ./gradlew report
       - name: Run SonarCloud Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:

--- a/acceptance-tests/src/test/resources/features/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/FraudCRI.feature
@@ -56,7 +56,7 @@ Feature: Fraud CRI
   @userSearch_by_invalid_userName @staging-fraud
   Scenario: User Search By Invalid UserName(STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
+    And I click the Fraud CRI for the testEnvironment
     When I search for user name Debra Kiritharnathan in the ThirdParty table
     And I click on Go to Fraud CRI link
     Then I navigate to the verifiable issuer to check for a Invalid response from thirdParty
@@ -88,9 +88,9 @@ Feature: Fraud CRI
     And The test is complete and I close the driver
 
   @happy_path_with_ci_fraud @staging-fraud
-  Scenario: User Journey Happy Path with A01 CI (STUB)
+  Scenario: User Journey Happy Path with A01 CI
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
+    And I click the Fraud CRI for the testEnvironment
     Then I search for user number 34 in the ThirdParty table
     And I navigate to the verifiable issuer to check for a Valid response from thirdParty
     And JSON payload should contain ci A01 and score 2
@@ -122,7 +122,7 @@ Feature: Fraud CRI
   @pep_test_all_users @staging-fraud
   Scenario Outline: Edit User Happy Path with pep CI (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
+    And I click the Fraud CRI for the testEnvironment
     And I search for user name LINDA DUFF in the ThirdParty table
     When I click on Edit User link
     And I am on Edit User page
@@ -169,7 +169,7 @@ Feature: Fraud CRI
   @test_PEP_user_with_multiple_addresses @staging-fraud
   Scenario Outline: Edit PEP User with multiple addresses (STUB)
     Given I navigate to the IPV Core Stub
-    And I click the Fraud CRI for the Staging environment
+    And I click the Fraud CRI for the testEnvironment
     And I search for user name LINDA DUFF in the ThirdParty table
     When I click on Edit User link
     Then I am on Edit User page

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ sonar {
 		property "sonar.java.coveragePlugin", "jacoco"
 		property "sonar.coverage.jacoco.xmlReportPath", "${buildDir}/reports/jacoco/reports/reports.xml"
 		property "sonar.dependencyCheck.htmlReportPath", "${buildDir}/reports/dependency-check-report.html"
+		property "sonar.dependencyCheck.htmlReportPath", "${buildDir}/reports/dependency-check-report.html"
+		property "sonar.issue.ignore.multicriteria", "s106"
+		property "sonar.issue.ignore.multicriteria.s106.ruleKey", "java:S106"
+		property "sonar.issue.ignore.multicriteria.s106.resourceKey", "lambdas/fraudcheck/src/main/java/*.java"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,9 @@ sonar {
 		property "sonar.coverage.jacoco.xmlReportPath", "${buildDir}/reports/jacoco/reports/reports.xml"
 		property "sonar.dependencyCheck.htmlReportPath", "${buildDir}/reports/dependency-check-report.html"
 		property "sonar.dependencyCheck.htmlReportPath", "${buildDir}/reports/dependency-check-report.html"
-		property "sonar.issue.ignore.multicriteria", "s106"
-		property "sonar.issue.ignore.multicriteria.s106.ruleKey", "java:S106"
-		property "sonar.issue.ignore.multicriteria.s106.resourceKey", "lambdas/fraudcheck/src/main/java/*.java"
+		property "sonar.issue.ignore.multicriteria", "e1"
+		property "sonar.issue.ignore.multicriteria.e1.ruleKey", "java:S107"
+		property "sonar.issue.ignore.multicriteria.e1.resourceKey", "**/*.java"
 	}
 }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
@@ -1,0 +1,85 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import software.amazon.lambda.powertools.parameters.ParamProvider;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+import java.net.URI;
+
+@ExcludeFromGeneratedCoverageReport
+public class CrosscoreV2Configuration {
+
+    private final String parameterPrefix;
+    private final String stackParameterPrefix;
+    private final String tokenEndpoint;
+    private final String clientId;
+    private final String clientSecret;
+    private final String username;
+    private final String password;
+    private final String tokenTableName;
+    private final String userDomain;
+    private final URI endpointUri;
+    private final String tenantId;
+
+    public CrosscoreV2Configuration(
+            ParamProvider paramProvider, String parameterPrefix, String stackParameterPrefix) {
+        this.parameterPrefix = parameterPrefix;
+        this.stackParameterPrefix = stackParameterPrefix;
+
+        this.tokenEndpoint = paramProvider.get(getParameterName("CrosscoreV2/tokenEndpoint"));
+        this.clientId = paramProvider.get(getParameterName("CrosscoreV2/clientId"));
+        this.clientSecret = paramProvider.get(getParameterName("CrosscoreV2/clientSecret"));
+        this.username = paramProvider.get(getParameterName("CrosscoreV2/Username"));
+        this.password = paramProvider.get(getParameterName("CrosscoreV2/Password"));
+        this.userDomain = paramProvider.get(getParameterName("CrosscoreV2/userDomain"));
+
+        this.tokenTableName =
+                paramProvider.get(getStackParameterName("CrosscoreV2/tokenTableName"));
+        this.endpointUri =
+                URI.create(paramProvider.get(getParameterName("CrosscoreV2/endpointUrl")));
+        this.tenantId = paramProvider.get(getParameterName("CrosscoreV2/tenantId"));
+    }
+
+    public String getTokenEndpoint() {
+        return tokenEndpoint;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUserDomain() {
+        return userDomain;
+    }
+
+    public String getTokenTableName() {
+        return tokenTableName;
+    }
+
+    public URI getEndpointUri() {
+        return endpointUri;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    private String getParameterName(String parameterName) {
+        return String.format("/%s/%s", parameterPrefix, parameterName);
+    }
+
+    private String getStackParameterName(String parameterName) {
+        return String.format("/%s/%s", stackParameterPrefix, parameterName);
+    }
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
@@ -57,13 +57,8 @@ public class FraudCheckConfigurationService {
     private List<String> zeroScoreUcodes;
     private Integer noFileFoundThreshold;
     private final long fraudResultItemTtl;
-    private final String tokenEndpoint;
-    private final String clientId;
-    private final String clientSecret;
-    private final String username;
-    private final String password;
-    private final String tokenTableName;
-    private final String userDomain;
+
+    private final CrosscoreV2Configuration crosscoreV2Configuration;
 
     private final Clock clock;
 
@@ -102,17 +97,10 @@ public class FraudCheckConfigurationService {
         this.fraudResultItemTtl =
                 Long.parseLong(paramProvider.get(getCommonParameterName("SessionTtl")));
 
-        // *************************Authenticate Parameters***************************
+        // *************************CrosscoreV2 Parameters***************************
 
-        this.tokenEndpoint = paramProvider.get(getParameterName("CrosscoreV2/tokenEndpoint"));
-        this.clientId = paramProvider.get(getParameterName("CrosscoreV2/clientId"));
-        this.clientSecret = paramProvider.get(getParameterName("CrosscoreV2/clientSecret"));
-        this.username = paramProvider.get(getParameterName("CrosscoreV2/Username"));
-        this.password = paramProvider.get(getParameterName("CrosscoreV2/Password"));
-        this.userDomain = paramProvider.get(getParameterName("CrosscoreV2/userDomain"));
-
-        this.tokenTableName =
-                paramProvider.get(getStackParameterName("CrosscoreV2/tokenTableName"));
+        this.crosscoreV2Configuration =
+                new CrosscoreV2Configuration(paramProvider, parameterPrefix, stackParameterPrefix);
 
         // *****************************Feature Toggles*******************************
 
@@ -166,6 +154,10 @@ public class FraudCheckConfigurationService {
         return contraindicationMappings;
     }
 
+    public CrosscoreV2Configuration getCrosscoreV2Configuration() {
+        return crosscoreV2Configuration;
+    }
+
     public boolean crosscoreV2Enabled() {
         return crosscoreV2Enabled;
     }
@@ -192,34 +184,6 @@ public class FraudCheckConfigurationService {
 
     public void setNoFileFoundThreshold(Integer noFileFoundThreshold) {
         this.noFileFoundThreshold = noFileFoundThreshold;
-    }
-
-    public String getTokenEndpoint() {
-        return tokenEndpoint;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public String getUserDomain() {
-        return userDomain;
-    }
-
-    public String getTokenTableName() {
-        return tokenTableName;
     }
 
     public long getFraudResultItemExpirationEpoch() {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidator.java
@@ -80,7 +80,6 @@ public class IdentityVerificationInfoResponseValidator {
         return new ValidationResult<>(validationErrors.isEmpty(), validationErrors);
     }
 
-    // TODO: will need to be reviewed in LIME-37
     public ValidationResult<List<String>> validatePEP(PEPResponse response) {
 
         final List<String> validationErrors = new ArrayList<>();

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
@@ -73,7 +73,7 @@ public class TokenRequestService {
             "Token expiry window not valid";
 
     public TokenRequestService(
-            FraudCheckConfigurationService fraudCheckConfigurationService,
+            CrosscoreV2Configuration crosscoreV2Configuration,
             DynamoDbEnhancedClient dynamoDbEnhancedClient,
             HttpRetryer httpRetryer,
             RequestConfig requestConfig,
@@ -81,15 +81,15 @@ public class TokenRequestService {
             EventProbe eventProbe) {
 
         // Token Table
-        this.tokenTableName = fraudCheckConfigurationService.getTokenTableName();
+        this.tokenTableName = crosscoreV2Configuration.getTokenTableName();
         this.dataStore = new DataStore<>(tokenTableName, TokenItem.class, dynamoDbEnhancedClient);
 
-        this.clientSecret = fraudCheckConfigurationService.getClientSecret();
-        this.clientId = fraudCheckConfigurationService.getClientId();
-        this.requestURI = URI.create(fraudCheckConfigurationService.getTokenEndpoint());
-        this.username = fraudCheckConfigurationService.getUsername();
-        this.password = fraudCheckConfigurationService.getPassword();
-        this.userDomain = fraudCheckConfigurationService.getUserDomain();
+        this.clientSecret = crosscoreV2Configuration.getClientSecret();
+        this.clientId = crosscoreV2Configuration.getClientId();
+        this.requestURI = URI.create(crosscoreV2Configuration.getTokenEndpoint());
+        this.username = crosscoreV2Configuration.getUsername();
+        this.password = crosscoreV2Configuration.getPassword();
+        this.userDomain = crosscoreV2Configuration.getUserDomain();
 
         this.httpRetryer = httpRetryer;
         this.requestConfig = requestConfig;

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
+import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
 import uk.gov.di.ipv.cri.fraud.api.service.HttpRetryer;
 import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.util.HTTPReply;
@@ -58,13 +59,12 @@ class ThirdPartyPepGatewayTest {
 
     private static final String TEST_API_RESPONSE_BODY = "test-api-response-content";
     private static final String TEST_ENDPOINT_URL = "https://test-endpoint.co.uk";
-
+    private static final String TEST_ACCESS_TOKEN = "testTokenValue";
     private static final String HMAC_OF_REQUEST_BODY = "hmac-of-request-body";
-
     private ThirdPartyPepGateway thirdPartyPepGateway;
 
     @Mock private HttpRetryer mockHttpRetryer;
-
+    @Mock private CrosscoreV2Configuration mockCrosscoreV2Configuration;
     @Mock private IdentityVerificationRequestMapper mockRequestMapper;
     @Mock private IdentityVerificationResponseMapper mockResponseMapper;
     @Mock private ObjectMapper mockObjectMapper;
@@ -81,6 +81,7 @@ class ThirdPartyPepGatewayTest {
                         mockObjectMapper,
                         mockHmacGenerator,
                         TEST_ENDPOINT_URL,
+                        mockCrosscoreV2Configuration,
                         mockEventProbe);
     }
 
@@ -111,7 +112,8 @@ class ThirdPartyPepGatewayTest {
         when(this.mockResponseMapper.mapPEPResponse(testPepResponse))
                 .thenReturn(testPepCheckResult);
 
-        PepCheckResult actualPepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity);
+        PepCheckResult actualPepCheckResult =
+                thirdPartyPepGateway.performPepCheck(personIdentity, false, null);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
@@ -144,7 +146,7 @@ class ThirdPartyPepGatewayTest {
         assertNotNull(actualPepCheckResult);
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
-        assertHeaders(httpRequestCaptor);
+        assertHeaders(httpRequestCaptor, false);
     }
 
     @Test
@@ -183,7 +185,7 @@ class ThirdPartyPepGatewayTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> thirdPartyPepGateway.performPepCheck(personIdentity),
+                        () -> thirdPartyPepGateway.performPepCheck(personIdentity, false, null),
                         "Expected OAuthErrorResponseException");
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -218,7 +220,7 @@ class ThirdPartyPepGatewayTest {
 
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
-        assertHeaders(httpRequestCaptor);
+        assertHeaders(httpRequestCaptor, false);
     }
 
     @ParameterizedTest
@@ -246,7 +248,8 @@ class ThirdPartyPepGatewayTest {
                         eq("Pep Check")))
                 .thenReturn(new HTTPReply(errorStatus, null, TEST_API_RESPONSE_BODY));
 
-        PepCheckResult actualPepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity);
+        PepCheckResult actualPepCheckResult =
+                thirdPartyPepGateway.performPepCheck(personIdentity, false, null);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
@@ -280,10 +283,208 @@ class ThirdPartyPepGatewayTest {
         assertEquals(EXPECTED_ERROR, actualPepCheckResult.getErrorMessage());
         assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
-        assertHeaders(httpRequestCaptor);
+        assertHeaders(httpRequestCaptor, false);
     }
 
-    private void assertHeaders(ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor) {
+    // crosscoreV2 tests
+    @Test
+    void shouldInvokeCrosscoreV2PepApi() throws IOException, OAuthErrorResponseException {
+        final String testRequestBody = "serialisedPepApiRequest";
+        final PEPRequest testApiRequest = new PEPRequest();
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
+        PEPResponse testPepResponse = new PEPResponse();
+        PepCheckResult testPepCheckResult = new PepCheckResult();
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+
+        when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
+
+        ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor =
+                ArgumentCaptor.forClass(HttpPost.class);
+
+        when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check")))
+                .thenReturn(new HTTPReply(200, null, TEST_API_RESPONSE_BODY));
+
+        when(this.mockObjectMapper.readValue(TEST_API_RESPONSE_BODY, PEPResponse.class))
+                .thenReturn(testPepResponse);
+        when(this.mockResponseMapper.mapPEPResponse(testPepResponse))
+                .thenReturn(testPepCheckResult);
+
+        PepCheckResult actualPepCheckResult =
+                thirdPartyPepGateway.performPepCheck(personIdentity, true, TEST_ACCESS_TOKEN);
+
+        InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_VALID.withEndpointPrefix());
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
+        verify(mockObjectMapper).writeValueAsString(testApiRequest);
+        verify(mockHttpRetryer)
+                .sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check"));
+        verify(mockResponseMapper).mapPEPResponse(testPepResponse);
+
+        assertNotNull(actualPepCheckResult);
+        assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
+        assertHeaders(httpRequestCaptor, true);
+    }
+
+    @Test
+    void shouldReturnOAuthErrorResponseExceptionIfThirdPartyApiReturnsInvalidCrosscoreV2Response()
+            throws IOException, OAuthErrorResponseException {
+        final String testRequestBody = "serialisedCrossCoreApiRequest";
+        final PEPRequest testApiRequest = new PEPRequest();
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
+
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+
+        when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
+        ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor =
+                ArgumentCaptor.forClass(HttpPost.class);
+
+        when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check")))
+                .thenReturn(new HTTPReply(200, null, "}BAD JSON{"));
+
+        OAuthErrorResponseException expectedReturnedException =
+                new OAuthErrorResponseException(
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        ErrorResponse.FAILED_TO_MAP_PEP_CHECK_RESPONSE_BODY);
+
+        // Trigger the mapping failure via the mock
+        when(mockObjectMapper.readValue("}BAD JSON{", PEPResponse.class))
+                .thenThrow(
+                        new InputCoercionException(
+                                null, "Problem during json mapping", null, null));
+
+        OAuthErrorResponseException thrownException =
+                assertThrows(
+                        OAuthErrorResponseException.class,
+                        () ->
+                                thirdPartyPepGateway.performPepCheck(
+                                        personIdentity, true, TEST_ACCESS_TOKEN),
+                        "Expected OAuthErrorResponseException");
+
+        assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
+        assertEquals(expectedReturnedException.getErrorReason(), thrownException.getErrorReason());
+
+        InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_EXPECTED_HTTP_STATUS.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_INVALID.withEndpointPrefix());
+        verifyNoMoreInteractions(mockEventProbe);
+
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
+        verify(mockObjectMapper).writeValueAsString(testApiRequest);
+        verify(mockHttpRetryer)
+                .sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check"));
+
+        assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
+        assertHeaders(httpRequestCaptor, true);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "300", "400", "500", "-1",
+    })
+    void thirdPartyApiReturnsErrorOnHTTP300CrosscoreV2Response(int errorStatus)
+            throws IOException, OAuthErrorResponseException {
+        final String testRequestBody = "serialisedCrossCoreApiRequest";
+        final PEPRequest testApiRequest = new PEPRequest();
+
+        PersonIdentity personIdentity =
+                TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
+        when(mockRequestMapper.mapPEPPersonIdentity(personIdentity)).thenReturn(testApiRequest);
+
+        when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
+
+        ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor =
+                ArgumentCaptor.forClass(HttpPost.class);
+
+        when(mockHttpRetryer.sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check")))
+                .thenReturn(new HTTPReply(errorStatus, null, TEST_API_RESPONSE_BODY));
+
+        PepCheckResult actualPepCheckResult =
+                thirdPartyPepGateway.performPepCheck(personIdentity, true, TEST_ACCESS_TOKEN);
+
+        InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_CREATED.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_REQUEST_SEND_OK.withEndpointPrefix());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(eq(THIRD_PARTY_PEP_RESPONSE_LATENCY_MILLIS), anyDouble());
+        inOrderMockEventProbe
+                .verify(mockEventProbe)
+                .counterMetric(PEP_RESPONSE_TYPE_UNEXPECTED_HTTP_STATUS.withEndpointPrefix());
+        verifyNoMoreInteractions(mockEventProbe);
+
+        final String EXPECTED_ERROR =
+                ERROR_PEP_CHECK_RETURNED_UNEXPECTED_HTTP_STATUS_CODE.getMessage();
+
+        verify(mockRequestMapper).mapPEPPersonIdentity(personIdentity);
+        verify(mockObjectMapper).writeValueAsString(testApiRequest);
+
+        verify(mockHttpRetryer, times(1))
+                .sendHTTPRequestRetryIfAllowed(
+                        httpRequestCaptor.capture(),
+                        any(PepCheckHttpRetryStatusConfig.class),
+                        eq("Pep Check"));
+
+        assertNotNull(actualPepCheckResult);
+        assertEquals(EXPECTED_ERROR, actualPepCheckResult.getErrorMessage());
+        assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
+        assertHeaders(httpRequestCaptor, true);
+    }
+
+    private void assertHeaders(
+            ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor,
+            boolean crosscoreV2Enabled) {
         // Check Headers
         Map<String, String> httpHeadersKV =
                 Arrays.stream(httpRequestCaptor.getValue().getAllHeaders())
@@ -292,7 +493,13 @@ class ThirdPartyPepGatewayTest {
         assertNotNull(httpHeadersKV.get("Content-Type"));
         assertEquals("application/json", httpHeadersKV.get("Content-Type"));
 
-        assertNotNull(httpHeadersKV.get("Content-Type"));
-        assertEquals(HMAC_OF_REQUEST_BODY, httpHeadersKV.get("hmac-signature"));
+        if (crosscoreV2Enabled) {
+            assertNotNull(httpHeadersKV.get("Accept"));
+            assertEquals("application/json", httpHeadersKV.get("Accept"));
+            assertNotNull(httpHeadersKV.get("Authorization"));
+            assertEquals("Bearer " + TEST_ACCESS_TOKEN, httpHeadersKV.get("Authorization"));
+        } else {
+            assertEquals(HMAC_OF_REQUEST_BODY, httpHeadersKV.get("hmac-signature"));
+        }
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandlerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckConfigurationService;
 import uk.gov.di.ipv.cri.fraud.api.service.IdentityVerificationService;
 import uk.gov.di.ipv.cri.fraud.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
+import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 import uk.gov.di.ipv.cri.fraud.library.persistence.item.FraudResultItem;
 
 import java.io.IOException;
@@ -77,7 +78,7 @@ class FraudHandlerTest {
 
     @Test
     void handleResponseShouldReturnOkResponseWhenValidInputProvided()
-            throws IOException, SqsException {
+            throws IOException, SqsException, OAuthErrorResponseException {
         String testRequestBody = "request body";
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -190,7 +191,7 @@ class FraudHandlerTest {
 
     @Test
     void handleResponseShouldReturnOkResponseWhenSessionAttemptGreaterThanOneAndResultNotFound()
-            throws IOException, SqsException {
+            throws IOException, SqsException, OAuthErrorResponseException {
         String testRequestBody = "request body";
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -246,7 +247,7 @@ class FraudHandlerTest {
 
     @Test
     void handleResponseShouldReturnInternalServerErrorResponseWhenUnableToContactThirdPartyApi()
-            throws JsonProcessingException, SqsException {
+            throws JsonProcessingException, SqsException, OAuthErrorResponseException {
         String testRequestBody = "request body";
         String errorMessage = "error message";
         PersonIdentity testPersonIdentity = new PersonIdentity();

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
@@ -95,6 +95,12 @@ class FraudCheckConfigurationServiceTest {
         String tokenUserDomainKey = "CrosscoreV2/userDomain";
         String tokenUserDomainValue = "tokenUserDomainValue";
 
+        String crosscoreV2EndpointUrlKey = "CrosscoreV2/endpointUrl";
+        String crosscoreV2EndpointUrlValue = "crosscoreV2EndpointUrlValue";
+
+        String crosscoreV2TenantIdKey = "CrosscoreV2/tenantId";
+        String crosscoreV2TenantIdValue = "crosscoreV2TenantId";
+
         String crosscoreV2Enabled = "CrosscoreV2/enabled";
         boolean crosscoreV2EnabledValue = false;
 
@@ -133,8 +139,7 @@ class FraudCheckConfigurationServiceTest {
                                 sessionTtlKey)))
                 .thenReturn(String.valueOf(sessionTtlValue));
 
-        // **********************************CrossCoreV2
-        // Params*********************************************
+        // **********************************CrossCoreV2Params*********************************************
 
         when(mockParamProvider.get(
                         String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, tokenEndpointKey)))
@@ -165,6 +170,16 @@ class FraudCheckConfigurationServiceTest {
                         String.format(
                                 STACK_PARAMETER_FORMAT, AWS_STACK_NAME, experianTokenTableNameKey)))
                 .thenReturn(experianTokenTableValue);
+
+        when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2EndpointUrlKey)))
+                .thenReturn(crosscoreV2EndpointUrlValue);
+
+        when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2TenantIdKey)))
+                .thenReturn(crosscoreV2TenantIdValue);
 
         when(mockParamProvider.get(
                         String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2Enabled)))
@@ -261,13 +276,33 @@ class FraudCheckConfigurationServiceTest {
         // **********************************CrossCoreV2
         // Params*********************************************
 
-        assertEquals(tokenEndpointValue, fraudCheckConfigurationService.getTokenEndpoint());
-        assertEquals(tokenClientIdValue, fraudCheckConfigurationService.getClientId());
-        assertEquals(tokenClientSecretValue, fraudCheckConfigurationService.getClientSecret());
-        assertEquals(tokenUserNameValue, fraudCheckConfigurationService.getUsername());
-        assertEquals(tokenPasswordValue, fraudCheckConfigurationService.getPassword());
-        assertEquals(tokenUserDomainValue, fraudCheckConfigurationService.getUserDomain());
-        assertEquals(experianTokenTableValue, fraudCheckConfigurationService.getTokenTableName());
+        assertEquals(
+                tokenEndpointValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenEndpoint());
+        assertEquals(
+                tokenClientIdValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getClientId());
+        assertEquals(
+                tokenClientSecretValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getClientSecret());
+        assertEquals(
+                tokenUserNameValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getUsername());
+        assertEquals(
+                tokenPasswordValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getPassword());
+        assertEquals(
+                tokenUserDomainValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getUserDomain());
+        assertEquals(
+                experianTokenTableValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());
+        assertEquals(
+                experianTokenTableValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());
+        assertEquals(
+                experianTokenTableValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());
         assertEquals(crosscoreV2EnabledValue, fraudCheckConfigurationService.crosscoreV2Enabled());
         // ***************************************************************************************************
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
@@ -27,8 +27,20 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceFactoryTest {
+
+    private static final String TEST_TOKEN_CLIENTID = "testTokenClientIdValue";
+    private static final String TEST_TOKEN_ENDPOINT = "testTokenEndpointValue";
+    private static final String TEST_TOKEN_CLIENT_SECRET = "testTokenClientSecretValue";
+    private static final String TEST_TOKEN_USERNAME = "testTokenUsernameValue";
+    private static final String TEST_TOKEN_PASSWORD = "testTokenPasswordValue";
+    private static final String TEST_TOKEN_USER_DOMAIN = "testTokenUserDomainValue";
+    private static final String TEST_TOKEN_TABLE_NAME = "testTokenTokenTableNameValue";
+    private static final String TEST_CROSSCOREV2_ENDPOINTURL = "testCrosscoreV2EndpointUrlValue";
+    private static final String TEST_CROSSCOREV2_TENANTID = "testCrosscoreV2TenantIdValue";
+
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private FraudCheckConfigurationService mockFraudCheckConfigurationService;
+    @Mock private CrosscoreV2Configuration mockCrosscoreV2Configuration;
     @Mock private ContraindicationMapper mockContraindicationMapper;
     @Mock private PersonIdentityValidator mockPersonIdentityValidator;
     @Mock private HttpClient mockHttpClient;
@@ -41,6 +53,7 @@ class ServiceFactoryTest {
     void shouldCreateIdentityVerificationService()
             throws NoSuchAlgorithmException, InvalidKeyException, HttpException, KeyStoreException,
                     CertificateException, IOException {
+        when(mockFraudCheckConfigurationService.crosscoreV2Enabled()).thenReturn(Boolean.FALSE);
         when(mockFraudCheckConfigurationService.getHmacKey()).thenReturn("hmac key");
         when(mockFraudCheckConfigurationService.getEndpointUrl())
                 .thenReturn("https://test-endpoint");
@@ -54,6 +67,16 @@ class ServiceFactoryTest {
         when(mockFraudCheckConfigurationService.getKeyStorePassword())
                 .thenReturn(testKeyStorePassword);
 
+        when(mockCrosscoreV2Configuration.getTokenEndpoint()).thenReturn(TEST_TOKEN_ENDPOINT);
+        when(mockCrosscoreV2Configuration.getClientId()).thenReturn(TEST_TOKEN_CLIENTID);
+        when(mockCrosscoreV2Configuration.getClientSecret()).thenReturn(TEST_TOKEN_CLIENT_SECRET);
+        when(mockCrosscoreV2Configuration.getUsername()).thenReturn(TEST_TOKEN_USERNAME);
+        when(mockCrosscoreV2Configuration.getPassword()).thenReturn(TEST_TOKEN_PASSWORD);
+        when(mockCrosscoreV2Configuration.getUserDomain()).thenReturn(TEST_TOKEN_USER_DOMAIN);
+        when(mockCrosscoreV2Configuration.getTokenTableName()).thenReturn(TEST_TOKEN_TABLE_NAME);
+
+        when(mockFraudCheckConfigurationService.getCrosscoreV2Configuration())
+                .thenReturn(mockCrosscoreV2Configuration);
         ServiceFactory serviceFactory =
                 new ServiceFactory(
                         mockObjectMapper,
@@ -67,7 +90,54 @@ class ServiceFactoryTest {
                 serviceFactory.getIdentityVerificationService();
 
         assertNotNull(identityVerificationService);
-        verify(mockFraudCheckConfigurationService, times(2)).getTenantId();
+        verify(mockFraudCheckConfigurationService, times(1)).getTenantId();
+        verify(mockFraudCheckConfigurationService, times(2)).getHmacKey();
+        verify(mockFraudCheckConfigurationService, times(2)).getEndpointUrl();
+    }
+
+    @Test
+    void shouldCreateIdentityVerificationServiceWhenCrosscoreV2Enabled()
+            throws NoSuchAlgorithmException, InvalidKeyException, HttpException, KeyStoreException,
+                    CertificateException, IOException {
+        when(mockFraudCheckConfigurationService.crosscoreV2Enabled()).thenReturn(Boolean.TRUE);
+        when(mockFraudCheckConfigurationService.getHmacKey()).thenReturn("hmac key");
+        when(mockFraudCheckConfigurationService.getEndpointUrl())
+                .thenReturn("https://test-endpoint");
+
+        // Test needs a real keystore as it is auto mapped from strings
+        final char[] unitTestKeyStorePassword = UUID.randomUUID().toString().toCharArray();
+        String testKeyStore = generateUnitTestKeyStore(unitTestKeyStorePassword);
+        String testKeyStorePassword = new String(unitTestKeyStorePassword);
+
+        when(mockFraudCheckConfigurationService.getEncodedKeyStore()).thenReturn(testKeyStore);
+        when(mockFraudCheckConfigurationService.getKeyStorePassword())
+                .thenReturn(testKeyStorePassword);
+
+        when(mockCrosscoreV2Configuration.getTokenEndpoint()).thenReturn(TEST_TOKEN_ENDPOINT);
+        when(mockCrosscoreV2Configuration.getClientId()).thenReturn(TEST_TOKEN_CLIENTID);
+        when(mockCrosscoreV2Configuration.getClientSecret()).thenReturn(TEST_TOKEN_CLIENT_SECRET);
+        when(mockCrosscoreV2Configuration.getUsername()).thenReturn(TEST_TOKEN_USERNAME);
+        when(mockCrosscoreV2Configuration.getPassword()).thenReturn(TEST_TOKEN_PASSWORD);
+        when(mockCrosscoreV2Configuration.getUserDomain()).thenReturn(TEST_TOKEN_USER_DOMAIN);
+        when(mockCrosscoreV2Configuration.getTokenTableName()).thenReturn(TEST_TOKEN_TABLE_NAME);
+
+        when(mockFraudCheckConfigurationService.getCrosscoreV2Configuration())
+                .thenReturn(mockCrosscoreV2Configuration);
+        ServiceFactory serviceFactory =
+                new ServiceFactory(
+                        mockObjectMapper,
+                        mockEventProbe,
+                        mockFraudCheckConfigurationService,
+                        mockContraindicationMapper,
+                        mockPersonIdentityValidator,
+                        mockAuditService);
+
+        IdentityVerificationService identityVerificationService =
+                serviceFactory.getIdentityVerificationService();
+
+        assertNotNull(identityVerificationService);
+        verify(mockFraudCheckConfigurationService.getCrosscoreV2Configuration(), times(1))
+                .getTenantId();
         verify(mockFraudCheckConfigurationService, times(2)).getHmacKey();
         verify(mockFraudCheckConfigurationService, times(2)).getEndpointUrl();
     }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
@@ -75,7 +75,7 @@ class TokenRequestServiceTest {
     private static final String expectedClientId = "test-clientId";
     private static final String expectedClientSecret = "test-clientSecret";
 
-    @Mock FraudCheckConfigurationService mockFraudConfigurationService;
+    @Mock CrosscoreV2Configuration mockCrosscoreV2Configuration;
     @Mock DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     @Mock HttpRetryer mockHttpRetryer;
     @Mock private RequestConfig mockRequestConfig;
@@ -91,13 +91,13 @@ class TokenRequestServiceTest {
     void setUp() {
         realObjectMapper = new ObjectMapper();
 
-        when(mockFraudConfigurationService.getTokenEndpoint()).thenReturn(TEST_END_POINT);
-        when(mockFraudConfigurationService.getTokenTableName()).thenReturn(TEST_TOKEN_TABLE_NAME);
-        when(mockFraudConfigurationService.getUsername()).thenReturn(TEST_USER_NAME);
-        when(mockFraudConfigurationService.getPassword()).thenReturn(TEST_PASSWORD);
-        when(mockFraudConfigurationService.getClientId()).thenReturn(expectedClientId);
-        when(mockFraudConfigurationService.getClientSecret()).thenReturn(expectedClientSecret);
-        when(mockFraudConfigurationService.getUserDomain()).thenReturn(TEST_USER_DOMAIN);
+        when(mockCrosscoreV2Configuration.getTokenEndpoint()).thenReturn(TEST_END_POINT);
+        when(mockCrosscoreV2Configuration.getTokenTableName()).thenReturn(TEST_TOKEN_TABLE_NAME);
+        when(mockCrosscoreV2Configuration.getUsername()).thenReturn(TEST_USER_NAME);
+        when(mockCrosscoreV2Configuration.getPassword()).thenReturn(TEST_PASSWORD);
+        when(mockCrosscoreV2Configuration.getClientId()).thenReturn(expectedClientId);
+        when(mockCrosscoreV2Configuration.getClientSecret()).thenReturn(expectedClientSecret);
+        when(mockCrosscoreV2Configuration.getUserDomain()).thenReturn(TEST_USER_DOMAIN);
 
         // Datastore is wrapper around DynamoDbEnhancedClient
         when(mockDynamoDbEnhancedClient.table(eq(TEST_TOKEN_TABLE_NAME), any(TableSchema.class)))
@@ -105,7 +105,7 @@ class TokenRequestServiceTest {
 
         tokenRequestService =
                 new TokenRequestService(
-                        mockFraudConfigurationService,
+                        mockCrosscoreV2Configuration,
                         mockDynamoDbEnhancedClient,
                         mockHttpRetryer,
                         mockRequestConfig,


### PR DESCRIPTION
- Made updates to the ThirdPartyGateways to facilitate a call to CrosscoreV2 conditionally (based on the value of CrosscoreV2/enabled feature toggle parameter).
- Refactored FraudCheckConfigurationService parameters related to CrosscoreV2 to live inside of a new configuration class called crosscoreV2Configuration (Also refactored TokenRequestService to use this new configuration)
- Updated ServiceFactory to pass the tenantID used in IdentityVerificationRequestMapper conditionally based on V2 feature toggle parameter
- Wrote unit tests to cover new route
- Added fix to Sonar unit Test coverage calculations