### PR TITLE
LIME-1010 Correct warningsErrors responseType to be mapped as string instead of an enum

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: true
       - name: Set up JDK 17
         uses: actions/setup-java@v2
@@ -85,39 +86,6 @@ jobs:
           path: |
             */build/reports/
           retention-days: 5
-      - name: Cache Unit Test Reports
-        uses: actions/cache@v2
-        with:
-          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
-          path: |
-            */build/jacoco/
-            */build/reports/
-
-  run-sonar-analysis:
-    runs-on: ubuntu-latest
-    needs:
-      - run-unit-tests
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          submodules: true
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: 17
-          distribution: zulu
-          cache: 'gradle'
-      - name: Build Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            .gradle/
-            */build/
-            !*/build/reports
-            !*/build/jacoco
-          key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Cache Unit Test Reports
         uses: actions/cache@v2
         with:

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/WarningsErrors.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/WarningsErrors.java
@@ -7,7 +7,7 @@ public class WarningsErrors {
     private String responseCode;
 
     @JsonProperty("responseType")
-    private ResponseType responseType;
+    private String responseType;
 
     @JsonProperty("responseMessage")
     private String responseMessage;
@@ -20,11 +20,11 @@ public class WarningsErrors {
         return responseCode;
     }
 
-    public void setResponseType(ResponseType responseType) {
+    public void setResponseType(String responseType) {
         this.responseType = responseType;
     }
 
-    public ResponseType getResponseType() {
+    public String getResponseType() {
         return responseType;
     }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationWarningsErrorsLogger.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationWarningsErrorsLogger.java
@@ -1,0 +1,101 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.WarningsErrors;
+
+import java.util.List;
+
+public class IdentityVerificationWarningsErrorsLogger {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static final String CANNOT_LOCATE_WARNINGS_ERRORS =
+            "Cannot locate Warnings/Errors as response had null entries";
+
+    public static final String NO_WARNINGS_ERRORS_FORMAT =
+            "%s - did not contain Warnings/Errors array";
+
+    public static final String NULL_WARNINGS_ERRORS_ELEMENT_FORMAT =
+            "%s - Warnings/Errors array had an null element";
+
+    private static final String WARNINGS_ERRORS_LOG_FORMAT =
+            "%s - DecisionElement:ResponseType:%s listed in WarningsErrors, ResponseCode:%s, ResponseMessage:%s";
+
+    /** This class is intended log only with no impact on control flow. */
+    public IdentityVerificationWarningsErrorsLogger() {
+        /* No Args */
+    }
+
+    public void logAnyWarningsErrors(IdentityVerificationResponse response) {
+        if (null != response
+                && null != response.getClientResponsePayload()
+                && null != response.getClientResponsePayload().getDecisionElements()
+                && null != response.getClientResponsePayload().getDecisionElements().get(0)) {
+
+            String logLinePrefix = getLogLinePrefix(response);
+
+            List<WarningsErrors> warningsErrors =
+                    response.getClientResponsePayload()
+                            .getDecisionElements()
+                            .get(0)
+                            .getWarningsErrors();
+
+            processWarningsErrors(logLinePrefix, warningsErrors);
+
+        } else {
+            LOGGER.error(CANNOT_LOCATE_WARNINGS_ERRORS);
+        }
+    }
+
+    private String getLogLinePrefix(IdentityVerificationResponse response) {
+        String responseType = null;
+        if (null != response.getResponseHeader()
+                && null != response.getResponseHeader().getResponseType()) {
+            responseType = String.valueOf(response.getResponseHeader().getResponseType());
+        }
+
+        String requestType = null;
+        if (null != response.getResponseHeader()
+                && null != response.getResponseHeader().getRequestType()) {
+            requestType = response.getResponseHeader().getRequestType();
+        }
+
+        return String.format("%s - %s", requestType, responseType);
+    }
+
+    private void processWarningsErrors(String logLinePrefix, List<WarningsErrors> warningsErrors) {
+        // Responses where WarningsErrors is null or empty are expected
+        if (null != warningsErrors && !warningsErrors.isEmpty()) {
+            for (WarningsErrors warningError : warningsErrors) {
+                processWarningError(logLinePrefix, warningError);
+            }
+        } else {
+            String logMessage = String.format(NO_WARNINGS_ERRORS_FORMAT, logLinePrefix);
+            LOGGER.info(logMessage);
+        }
+    }
+
+    private void processWarningError(String logLinePrefix, WarningsErrors warningError) {
+        if (null != warningError) {
+            String responseType = warningError.getResponseType();
+            String responseMessage = warningError.getResponseMessage();
+            String responseCode = warningError.getResponseCode();
+
+            String logMessage =
+                    String.format(
+                            WARNINGS_ERRORS_LOG_FORMAT,
+                            logLinePrefix,
+                            responseType,
+                            responseCode,
+                            responseMessage);
+
+            LOGGER.warn(logMessage);
+        } else {
+            // Not expected to happen but logged if it does
+            String logMessage = String.format(NULL_WARNINGS_ERRORS_ELEMENT_FORMAT, logLinePrefix);
+            LOGGER.warn(logMessage);
+        }
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.di.ipv.cri.fraud.api.domain.ValidationResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
@@ -2814,12 +2816,74 @@ public class IdentityVerificationInfoResponseValidatorTest {
         assertTrue(validationResult.isValid());
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        // responseType value, expected value for validationResult.isValid()
+        "INFO, true",
+        "Info, true",
+        "info, true",
+        "WARN, true",
+        "Warn, true",
+        "warn, true",
+        "WARNING, true",
+        "Warning, true",
+        "warning, true",
+        "null, true",
+        "8, true",
+        "ERROR, false",
+        "Error, false",
+        "error, false",
+    })
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeStringsAreOK(
+            String responseTypeScenario, boolean expectedIsValid) {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode(len10String.repeat(4));
+        warningError.setResponseMessage("Message");
+
+        String responseType = responseTypeScenario.equals("null") ? null : responseTypeScenario;
+
+        warningError.setResponseType(responseType);
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+
+        if (expectedIsValid) {
+            assertEquals(0, validationResult.getError().size());
+        } else {
+            assertEquals(1, validationResult.getError().size());
+        }
+        assertEquals(expectedIsValid, validationResult.isValid());
+    }
+
     @Test
     void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseCodeMaxLenOK() {
         final WarningsErrors warningError = new WarningsErrors();
         warningError.setResponseCode(len10String.repeat(4));
         warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.INFO);
+        warningError.setResponseType(ResponseType.INFO.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -2855,7 +2919,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
         final WarningsErrors warningError = new WarningsErrors();
         warningError.setResponseCode(len10String.repeat(4) + "1");
         warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.INFO);
+        warningError.setResponseType(ResponseType.INFO.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -2892,11 +2956,47 @@ public class IdentityVerificationInfoResponseValidatorTest {
     }
 
     @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseCodeNullIsOK() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode(null);
+        warningError.setResponseMessage("Message");
+        warningError.setResponseType(ResponseType.INFO.toString());
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
     void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseMessageMaxLenOK() {
         final WarningsErrors warningError = new WarningsErrors();
         warningError.setResponseCode("1");
         warningError.setResponseMessage(len10String.repeat(30));
-        warningError.setResponseType(ResponseType.INFO);
+        warningError.setResponseType(ResponseType.INFO.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -2933,7 +3033,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
         final WarningsErrors warningError = new WarningsErrors();
         warningError.setResponseCode("1");
         warningError.setResponseMessage(len10String.repeat(30) + "1");
-        warningError.setResponseType(ResponseType.INFO);
+        warningError.setResponseType(ResponseType.INFO.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -2970,12 +3070,48 @@ public class IdentityVerificationInfoResponseValidatorTest {
     }
 
     @Test
+    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseMessageNullIsOK() {
+        final WarningsErrors warningError = new WarningsErrors();
+        warningError.setResponseCode("1");
+        warningError.setResponseMessage(null);
+        warningError.setResponseType(ResponseType.INFO.toString());
+
+        testIVResponse
+                .getClientResponsePayload()
+                .getDecisionElements()
+                .get(0)
+                .setWarningsErrors(List.of(warningError));
+
+        ValidationResult<List<String>> validationResult =
+                infoResponseValidator.validate(testIVResponse);
+
+        assertEquals(
+                1,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .size());
+        assertEquals(
+                warningError,
+                testIVResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .get(0));
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
     void
             clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeErrorIsFailWithSafeToLogWarningError() {
         WarningsErrors warningError = new WarningsErrors();
         warningError.setResponseCode("1");
         warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.ERROR);
+        warningError.setResponseType(ResponseType.ERROR.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -2987,7 +3123,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
                 infoResponseValidator.validate(testIVResponse);
 
         final String EXPECTED_ERROR =
-                "DecisionElement:ResponseType:Error, ResponseCode:"
+                "DecisionElement:ResponseType:ERROR listed in WarningsErrors, ResponseCode:"
                         + warningError.getResponseCode()
                         + ", ResponseMessage:"
                         + warningError.getResponseMessage();
@@ -3020,7 +3156,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
         final String CODE = len10String.repeat(4) + "1";
         warningError.setResponseCode(CODE);
         warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.ERROR);
+        warningError.setResponseType(ResponseType.ERROR.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -3032,7 +3168,10 @@ public class IdentityVerificationInfoResponseValidatorTest {
                 infoResponseValidator.validate(testIVResponse);
 
         final String EXPECTED_ERROR =
-                IdentityVerificationInfoResponseValidator.WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE;
+                String.format(
+                        IdentityVerificationInfoResponseValidator
+                                .WARNINGS_ERRORS_FALL_BACK_ERROR_MESSAGE_FORMAT,
+                        "ERROR");
 
         assertEquals(
                 1,
@@ -3063,7 +3202,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
         final String MESSAGE = len10String.repeat(30) + "1";
         warningError.setResponseCode("1");
         warningError.setResponseMessage(MESSAGE);
-        warningError.setResponseType(ResponseType.ERROR);
+        warningError.setResponseType(ResponseType.ERROR.toString());
 
         testIVResponse
                 .getClientResponsePayload()
@@ -3075,7 +3214,10 @@ public class IdentityVerificationInfoResponseValidatorTest {
                 infoResponseValidator.validate(testIVResponse);
 
         final String EXPECTED_ERROR =
-                IdentityVerificationInfoResponseValidator.WARNINGS_ERRORS_FALL_BACK_ERROR_MESAGE;
+                String.format(
+                        IdentityVerificationInfoResponseValidator
+                                .WARNINGS_ERRORS_FALL_BACK_ERROR_MESSAGE_FORMAT,
+                        "ERROR");
 
         assertEquals(
                 1,
@@ -3097,113 +3239,5 @@ public class IdentityVerificationInfoResponseValidatorTest {
         assertEquals(2, validationResult.getError().size());
         assertEquals(EXPECTED_ERROR, validationResult.getError().get(1));
         assertFalse(validationResult.isValid());
-    }
-
-    @Test
-    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeInfoIsOK() {
-        final WarningsErrors warningError = new WarningsErrors();
-        warningError.setResponseCode("1");
-        warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.INFO);
-
-        testIVResponse
-                .getClientResponsePayload()
-                .getDecisionElements()
-                .get(0)
-                .setWarningsErrors(List.of(warningError));
-
-        ValidationResult<List<String>> validationResult =
-                infoResponseValidator.validate(testIVResponse);
-
-        assertEquals(
-                1,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .size());
-        assertEquals(
-                warningError,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .get(0));
-        assertEquals(0, validationResult.getError().size());
-        assertTrue(validationResult.isValid());
-    }
-
-    @Test
-    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeWarnIsOK() {
-        WarningsErrors warningError = new WarningsErrors();
-        warningError.setResponseCode("1");
-        warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.WARN);
-
-        testIVResponse
-                .getClientResponsePayload()
-                .getDecisionElements()
-                .get(0)
-                .setWarningsErrors(List.of(warningError));
-
-        ValidationResult<List<String>> validationResult =
-                infoResponseValidator.validate(testIVResponse);
-
-        assertEquals(
-                1,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .size());
-        assertEquals(
-                warningError,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .get(0));
-        assertEquals(0, validationResult.getError().size());
-        assertTrue(validationResult.isValid());
-    }
-
-    @Test
-    void clientPayloadDecisionElementsDecisionElementWarningsErrorsResponseTypeWarningIsOK() {
-        WarningsErrors warningError = new WarningsErrors();
-        warningError.setResponseCode("1");
-        warningError.setResponseMessage("Message");
-        warningError.setResponseType(ResponseType.WARNING);
-
-        testIVResponse
-                .getClientResponsePayload()
-                .getDecisionElements()
-                .get(0)
-                .setWarningsErrors(List.of(warningError));
-
-        ValidationResult<List<String>> validationResult =
-                infoResponseValidator.validate(testIVResponse);
-
-        assertEquals(
-                1,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .size());
-        assertEquals(
-                warningError,
-                testIVResponse
-                        .getClientResponsePayload()
-                        .getDecisionElements()
-                        .get(0)
-                        .getWarningsErrors()
-                        .get(0));
-        assertEquals(0, validationResult.getError().size());
-        assertTrue(validationResult.isValid());
     }
 }

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationWarningsErrorsLoggerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationWarningsErrorsLoggerTest.java
@@ -1,0 +1,175 @@
+package uk.gov.di.ipv.cri.fraud.api.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.ResponseType;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.WarningsErrors;
+import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityVerificationWarningsErrorsLoggerTest {
+
+    private IdentityVerificationWarningsErrorsLogger identityVerificationWarningsErrorsLogger;
+
+    @BeforeEach
+    void setUp() {
+        identityVerificationWarningsErrorsLogger = new IdentityVerificationWarningsErrorsLogger();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "HappyPathInfo",
+                "HappyPathError",
+                "Null Response",
+                "Null ClientResponsePayload",
+                "Null DecisionElements",
+                "DecisionElements Null Element",
+                "Null Response Header",
+                "Null Response Header ResponseType",
+                "Null Response Header RequestType",
+                "Null warningsErrors",
+                "Empty warningsErrors",
+                "WarningsErrors null warning",
+                "Warning null responseType",
+                "Warning null responseCode",
+                "Warning null responseMessage"
+            })
+    void canHandleResponseScenarios(String scenario) throws Exception {
+
+        IdentityVerificationResponse response = getResponseScenario(scenario);
+
+        assertDoesNotThrow(
+                () -> identityVerificationWarningsErrorsLogger.logAnyWarningsErrors(response));
+    }
+
+    private static IdentityVerificationResponse getResponseScenario(String scenario)
+            throws Exception {
+
+        IdentityVerificationResponse identityVerificationResponse =
+                TestDataCreator.createTestVerificationResponse(ResponseType.INFO);
+
+        switch (scenario) {
+            case "HappyPathInfo" -> {
+                return identityVerificationResponse;
+            }
+            case "HappyPathError" -> {
+                identityVerificationResponse =
+                        TestDataCreator.createTestVerificationResponse(ResponseType.ERROR);
+
+                return identityVerificationResponse;
+            }
+            case "Null Response" -> {
+                return null;
+            }
+            case "Null ClientResponsePayload" -> identityVerificationResponse
+                    .setClientResponsePayload(null);
+            case "Null DecisionElements" -> identityVerificationResponse
+                    .getClientResponsePayload()
+                    .setDecisionElements(null);
+            case "DecisionElements Null Element" -> identityVerificationResponse
+                    .getClientResponsePayload()
+                    .getDecisionElements()
+                    .set(0, null);
+            case "Null Response Header" -> identityVerificationResponse.setResponseHeader(null);
+            case "Null Response Header ResponseType" -> identityVerificationResponse
+                    .getResponseHeader()
+                    .setResponseType(null);
+            case "Null Response Header RequestType" -> identityVerificationResponse
+                    .getResponseHeader()
+                    .setRequestType(null);
+            case "Null warningsErrors" -> identityVerificationResponse
+                    .getClientResponsePayload()
+                    .getDecisionElements()
+                    .get(0)
+                    .setWarningsErrors(null);
+            case "Empty warningsErrors" -> identityVerificationResponse
+                    .getClientResponsePayload()
+                    .getDecisionElements()
+                    .get(0)
+                    .setWarningsErrors(new ArrayList<>());
+            case "WarningsErrors null warning" -> {
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .setWarningsErrors(new ArrayList<>());
+
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .add(0, null);
+            }
+            case "Warning null responseType" -> {
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .setWarningsErrors(new ArrayList<>());
+
+                WarningsErrors warningsErrors = new WarningsErrors();
+                warningsErrors.setResponseType(null);
+                warningsErrors.setResponseCode("ResponseCode");
+                warningsErrors.setResponseMessage("ResponseMessage");
+
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .add(0, warningsErrors);
+            }
+            case "Warning null responseCode" -> {
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .setWarningsErrors(new ArrayList<>());
+
+                WarningsErrors warningsErrors = new WarningsErrors();
+                warningsErrors.setResponseType("ResponseType");
+                warningsErrors.setResponseCode(null);
+                warningsErrors.setResponseMessage("ResponseMessage");
+
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .add(0, warningsErrors);
+            }
+            case "Warning null responseMessage" -> {
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .setWarningsErrors(new ArrayList<>());
+
+                WarningsErrors warningsErrors = new WarningsErrors();
+                warningsErrors.setResponseType("ResponseType");
+                warningsErrors.setResponseCode("ResponseCode");
+                warningsErrors.setResponseMessage(null);
+
+                identityVerificationResponse
+                        .getClientResponsePayload()
+                        .getDecisionElements()
+                        .get(0)
+                        .getWarningsErrors()
+                        .add(0, warningsErrors);
+            }
+            default -> throw new Exception("Invalid Test Scenario - " + scenario);
+        }
+
+        return identityVerificationResponse;
+    }
+}


### PR DESCRIPTION
## Proposed changes

### What changed

Correct warningsErrors responseType to be mapped as string instead of an enum

Added dedicated logger for warnings and errors - IdentityVerificationWarningsErrorsLogger.

### Why did it change

"ResponseType" in warningsErrors, is indicated to be a String and have values that do not match the global enum "ResponseType".

IdentityVerificationWarningsErrorsLogger - 
- To allow the CRI to attempt to retrieve warnings/errors from all ResponseType if present, even if the response is not fully complete - to aid investigating response errors.
- To avoid changing the behaviour or adding the above unrelated functionality to the IdentityVerificationInfoResponseValidator.

### Issue tracking

- [LIME-1010](https://govukverify.atlassian.net/browse/LIME-1010)

[LIME-1010]: https://govukverify.atlassian.net/browse/LIME-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ