### PR TITLE
LIME-920 Align IdentityVerificationInfoResponseValidator with crosscore2 response

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/PersonIdentityValidator.java
@@ -39,7 +39,7 @@ class PersonIdentityValidator {
 
         if (Objects.isNull(personIdentity.getAddresses())) {
             validationErrors.add("Addresses" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX);
-        } else if (JsonValidationUtility.validateIntegerRangeData(
+        } else if (JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                 personIdentity.getAddresses().size(),
                 MIN_SUPPORTED_ADDRESSES,
                 MAX_SUPPORTED_ADDRESSES,

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtility.java
@@ -166,8 +166,17 @@ public final class JsonValidationUtility {
      * @param validationErrors A list in which to collect validation errors
      * @return true if validation passed or false if not.
      */
-    public static boolean validateIntegerRangeData(
-            int variable, int min, int max, String name, final List<String> validationErrors) {
+    public static boolean validateIntegerRangeDataNullIsFail(
+            Integer variable,
+            Integer min,
+            Integer max,
+            String name,
+            final List<String> validationErrors) {
+        if (variable == null) {
+            validationErrors.add(name + IS_NULL_ERROR_MESSAGE_SUFFIX);
+            return false;
+        }
+
         if (variable < min || variable > max) {
             validationErrors.add(createIntegerRangeErrorMessage(variable, min, max, name));
             return false;
@@ -177,7 +186,7 @@ public final class JsonValidationUtility {
     }
 
     public static String createIntegerRangeErrorMessage(
-            int variable, int min, int max, String name) {
+            Integer variable, Integer min, Integer max, String name) {
         return String.format(
                 JsonValidationUtility.INVALID_VALUE_RANGE_ERROR_MESSAGE_FORMAT,
                 name,

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationInfoResponseValidatorTest.java
@@ -72,7 +72,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void headerTenantIDCannotBeTooLong() {
-        final String TEST_STRING = len10String.repeat(3) + "1";
+        final String TEST_STRING = len10String.repeat(3) + "1234567";
         testIVResponse.getResponseHeader().setTenantID(TEST_STRING);
 
         ValidationResult<List<String>> validationResult =
@@ -89,7 +89,7 @@ public class IdentityVerificationInfoResponseValidatorTest {
 
     @Test
     void headerTenantIDMaxLenOK() {
-        final String TEST_STRING = len10String.repeat(3);
+        final String TEST_STRING = len10String.repeat(3) + "123456";
         testIVResponse.getResponseHeader().setTenantID(TEST_STRING);
 
         ValidationResult<List<String>> validationResult =
@@ -506,23 +506,18 @@ public class IdentityVerificationInfoResponseValidatorTest {
     }
 
     @Test
-    void headerOverallResponseDecisionTextCannotBeEmpty() {
+    void headerOverallResponseDecisionTextEmptyIsOk() {
         final String TEST_STRING = "";
         testIVResponse.getResponseHeader().getOverallResponse().setDecisionText(TEST_STRING);
 
         ValidationResult<List<String>> validationResult =
                 infoResponseValidator.validate(testIVResponse);
 
-        final String EXPECTED_ERROR =
-                "OverallResponse:DecisionText"
-                        + JsonValidationUtility.IS_EMPTY_ERROR_MESSAGE_SUFFIX;
-
         assertEquals(
                 TEST_STRING,
                 testIVResponse.getResponseHeader().getOverallResponse().getDecisionText());
-        assertEquals(1, validationResult.getError().size());
-        assertEquals(EXPECTED_ERROR, validationResult.getError().get(0));
-        assertFalse(validationResult.isValid());
+        assertEquals(0, validationResult.getError().size());
+        assertTrue(validationResult.isValid());
     }
 
     @Test

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/util/JsonValidationUtilityTest.java
@@ -18,7 +18,7 @@ class JsonValidationUtilityTest {
 
     private static List<String> TEST_LIST;
     private static String TEST_STRING;
-    private static int TEST_INT;
+    private static Integer TEST_INT;
     private static final int TEST_INT_RANGE_MIN = 0;
     private static final int TEST_INT_RANGE_MAX = 127;
     private static List<String> validationErrors;
@@ -390,7 +390,7 @@ class JsonValidationUtilityTest {
         TEST_INT = 63;
 
         boolean result =
-                JsonValidationUtility.validateIntegerRangeData(
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                         TEST_INT,
                         TEST_INT_RANGE_MIN,
                         TEST_INT_RANGE_MAX,
@@ -406,7 +406,7 @@ class JsonValidationUtilityTest {
         TEST_INT = TEST_INT_RANGE_MIN;
 
         boolean result =
-                JsonValidationUtility.validateIntegerRangeData(
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                         TEST_INT,
                         TEST_INT_RANGE_MIN,
                         TEST_INT_RANGE_MAX,
@@ -422,7 +422,7 @@ class JsonValidationUtilityTest {
         TEST_INT = TEST_INT_RANGE_MAX;
 
         boolean result =
-                JsonValidationUtility.validateIntegerRangeData(
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                         TEST_INT,
                         TEST_INT_RANGE_MIN,
                         TEST_INT_RANGE_MAX,
@@ -438,7 +438,7 @@ class JsonValidationUtilityTest {
         TEST_INT = TEST_INT_RANGE_MIN - 1;
 
         boolean result =
-                JsonValidationUtility.validateIntegerRangeData(
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                         TEST_INT,
                         TEST_INT_RANGE_MIN,
                         TEST_INT_RANGE_MAX,
@@ -459,7 +459,7 @@ class JsonValidationUtilityTest {
         TEST_INT = TEST_INT_RANGE_MAX + 1;
 
         boolean result =
-                JsonValidationUtility.validateIntegerRangeData(
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
                         TEST_INT,
                         TEST_INT_RANGE_MIN,
                         TEST_INT_RANGE_MAX,
@@ -469,6 +469,26 @@ class JsonValidationUtilityTest {
         final String EXPECTED_ERROR =
                 JsonValidationUtility.createIntegerRangeErrorMessage(
                         TEST_INT, TEST_INT_RANGE_MIN, TEST_INT_RANGE_MAX, TEST_INTEGER_NAME);
+
+        assertEquals(1, validationErrors.size());
+        assertEquals(EXPECTED_ERROR, validationErrors.get(0));
+        assertFalse(result);
+    }
+
+    @Test
+    void validateIntegerRangeData_FailsIfNull() {
+        TEST_INT = null;
+
+        boolean result =
+                JsonValidationUtility.validateIntegerRangeDataNullIsFail(
+                        TEST_INT,
+                        TEST_INT_RANGE_MIN,
+                        TEST_INT_RANGE_MAX,
+                        TEST_INTEGER_NAME,
+                        validationErrors);
+
+        final String EXPECTED_ERROR =
+                TEST_INTEGER_NAME + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
 
         assertEquals(1, validationErrors.size());
         assertEquals(EXPECTED_ERROR, validationErrors.get(0));


### PR DESCRIPTION
## Proposed changes

### What changed

Align IdentityVerificationInfoResponseValidator with Crosscore2 response.

Correct unboxing null pointer when response DecisionElement has no score field.

Moved warnings errors handling into separate method.

### Why did it change

Some fields previously returned as empty will now not be present.

Validation on the value range of the score, was unboxing a null Integer.
A null score will now fail the validator, as it is a required field.

warnings errors handling moved - to remove complexity code smell

### Issue tracking

- [LIME-920](https://govukverify.atlassian.net/browse/LIME-920)

[LIME-920]: https://govukverify.atlassian.net/browse/LIME-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ