### PR TITLE
LIME-1012 - Adding validation to accessToken JWT

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -941,6 +941,44 @@ Resources:
             Period: 60
             Stat: Sum
 
+  ExperianAuthenticateTokenRequestDeniedAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-${Environment} - Fraud - Experian Authenticate Token Request Denied Alarm"
+      AlarmDescription: !Sub Driving Licence ${Environment} Fraud Token endpoint returned an invalid response to a token request (failure to authenticate)
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicFraud
+      OKActions:
+        - !Ref AlarmTopicFraud
+      InsufficientDataActions: [ ]
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: CombinedTokenFailure
+          ReturnData: true
+          Expression: m1 + m2
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: di-ipv-cri-fraud-api
+              MetricName: token_api_response_type_invalid
+            Period: 60
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: di-ipv-cri-fraud-api
+              MetricName: token_failed_to_generate_new_token
+            Period: 60
+            Stat: Sum
+
   ####################################################################
   #                                                                  #
   # Alarm setup                                                      #

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AccessTokenHeader.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AccessTokenHeader.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+public class AccessTokenHeader {
+
+    @JsonProperty("alg")
+    private String algorithm;
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AccessTokenPayload.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/response/AccessTokenPayload.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+public class AccessTokenPayload {
+
+    @JsonProperty("sub")
+    private String username;
+
+    @JsonProperty("iss")
+    private String issuer;
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
@@ -19,6 +19,7 @@ public class CrosscoreV2Configuration {
     private final String userDomain;
     private final URI endpointUri;
     private final String tenantId;
+    private final String tokenIssuer;
 
     public CrosscoreV2Configuration(
             ParamProvider paramProvider, String parameterPrefix, String stackParameterPrefix) {
@@ -37,6 +38,7 @@ public class CrosscoreV2Configuration {
         this.endpointUri =
                 URI.create(paramProvider.get(getParameterName("CrosscoreV2/endpointUrl")));
         this.tenantId = paramProvider.get(getParameterName("CrosscoreV2/tenantId"));
+        this.tokenIssuer = paramProvider.get(getParameterName("CrosscoreV2/tokenIssuer"));
     }
 
     public String getTokenEndpoint() {
@@ -73,6 +75,10 @@ public class CrosscoreV2Configuration {
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getTokenIssuer() {
+        return tokenIssuer;
     }
 
     private String getParameterName(String parameterName) {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/AccessTokenValidator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/util/AccessTokenValidator.java
@@ -1,0 +1,61 @@
+package uk.gov.di.ipv.cri.fraud.api.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.AccessTokenHeader;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.AccessTokenPayload;
+import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
+
+import java.util.Base64;
+
+public class AccessTokenValidator {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String UNMAPPED = "unmapped";
+
+    private AccessTokenValidator() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+
+    public static boolean isTokenValid(
+            String accessToken,
+            ObjectMapper objectMapper,
+            CrosscoreV2Configuration crosscoreV2Configuration)
+            throws JsonProcessingException {
+        boolean isTokenValid = false;
+        String alg = UNMAPPED;
+        String sub = UNMAPPED;
+        String iss = UNMAPPED;
+
+        try {
+            String[] chunks = accessToken.split("\\.");
+
+            Base64.Decoder decoder = Base64.getUrlDecoder();
+            String header = new String(decoder.decode(chunks[0]));
+            String payload = new String(decoder.decode(chunks[1]));
+
+            AccessTokenHeader accessTokenHeader =
+                    objectMapper.readValue(header, AccessTokenHeader.class);
+            AccessTokenPayload accessTokenPayload =
+                    objectMapper.readValue(payload, AccessTokenPayload.class);
+
+            alg = accessTokenHeader.getAlgorithm();
+            sub = accessTokenPayload.getUsername();
+            iss = accessTokenPayload.getIssuer();
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Invalid JWT returned for access token");
+        }
+        if (alg.equalsIgnoreCase("RS256")
+                && sub.equalsIgnoreCase(crosscoreV2Configuration.getUsername())
+                && iss.equalsIgnoreCase(crosscoreV2Configuration.getTokenIssuer())) {
+            isTokenValid = true;
+        } else {
+            LOGGER.error(
+                    "Token jwt contains invalid value/s. alg {}, sub {}, iss {}", alg, sub, iss);
+        }
+
+        return isTokenValid;
+    }
+}

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
@@ -101,6 +101,9 @@ class FraudCheckConfigurationServiceTest {
         String crosscoreV2TenantIdKey = "CrosscoreV2/tenantId";
         String crosscoreV2TenantIdValue = "crosscoreV2TenantId";
 
+        String crosscoreV2TokenIssuerKey = "CrosscoreV2/tokenIssuer";
+        String crosscoreV2TokenIssuerValue = "crosscoreV2TokenIssuer";
+
         String crosscoreV2Enabled = "CrosscoreV2/enabled";
         boolean crosscoreV2EnabledValue = false;
 
@@ -182,6 +185,11 @@ class FraudCheckConfigurationServiceTest {
                 .thenReturn(crosscoreV2TenantIdValue);
 
         when(mockParamProvider.get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2TokenIssuerKey)))
+                .thenReturn(crosscoreV2TokenIssuerValue);
+
+        when(mockParamProvider.get(
                         String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2Enabled)))
                 .thenReturn(String.valueOf(crosscoreV2EnabledValue));
 
@@ -240,6 +248,12 @@ class FraudCheckConfigurationServiceTest {
         verify(mockParamProvider)
                 .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, tokenUserDomainKey));
         verify(mockParamProvider)
+                .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2TenantIdKey));
+        verify(mockParamProvider)
+                .get(
+                        String.format(
+                                STACK_PARAMETER_FORMAT, AWS_STACK_NAME, crosscoreV2TokenIssuerKey));
+        verify(mockParamProvider)
                 .get(
                         String.format(
                                 STACK_PARAMETER_FORMAT, AWS_STACK_NAME, experianTokenTableNameKey));
@@ -295,11 +309,11 @@ class FraudCheckConfigurationServiceTest {
                 tokenUserDomainValue,
                 fraudCheckConfigurationService.getCrosscoreV2Configuration().getUserDomain());
         assertEquals(
-                experianTokenTableValue,
-                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());
+                crosscoreV2TenantIdValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTenantId());
         assertEquals(
-                experianTokenTableValue,
-                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());
+                crosscoreV2TokenIssuerValue,
+                fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenIssuer());
         assertEquals(
                 experianTokenTableValue,
                 fraudCheckConfigurationService.getCrosscoreV2Configuration().getTokenTableName());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
@@ -35,6 +35,8 @@ public enum ErrorResponse {
     FAILED_TO_MAP_TOKEN_ENDPOINT_RESPONSE_BODY(4003, "Failed to map token endpoint response body"),
     ERROR_TOKEN_ENDPOINT_RETURNED_UNEXPECTED_HTTP_STATUS_CODE(
             4004, "token endpoint returned unexpected http status code"),
+    TOKEN_ENDPOINT_RETURNED_JWT_WITH_UNEXPECTED_VALUES_IN_RESPONSE(
+            4005, "token endpoint returned unexpected values in JWT"),
 
     FINAL_ERROR(-1, "Final Error");
 

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetric.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetric.java
@@ -40,6 +40,7 @@ public enum ThirdPartyAPIEndpointMetric {
     TOKEN_HTTP_RETRYER_REQUEST_SEND_RETRY(TOKEN, HTTP_RETRYER_REQUEST_SEND_RETRY),
     TOKEN_HTTP_RETRYER_SEND_MAX_RETRIES(TOKEN, HTTP_RETRYER_SEND_MAX_RETRIES),
     TOKEN_HTTP_RETRYER_SEND_ERROR(TOKEN, HTTP_RETRYER_SEND_ERROR),
+    TOKEN_RESPONSE_FAILED_TO_GENERATE_NEW_TOKEN_METRIC(TOKEN, "failed_to_generate_new_token"),
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // FRAUD End Point Metrics                                                                   //

--- a/lib/src/test/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetricTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/fraud/library/metrics/ThirdPartyAPIEndpointMetricTest.java
@@ -74,6 +74,10 @@ class ThirdPartyAPIEndpointMetricTest {
         expectedMetricsCaptureList.add(
                 String.format(expectedFormat, TOKEN, "status_code_alert_metric").toLowerCase());
 
+        // Add special case token status code alert metric
+        expectedMetricsCaptureList.add(
+                String.format(expectedFormat, TOKEN, "failed_to_generate_new_token").toLowerCase());
+
         // Sort the two lists so the orders are the same
         Collections.sort(expectedMetricsCaptureList);
         Collections.sort(enumGeneratedMetricsStrings);


### PR DESCRIPTION
### What changed

 - Added validation to accessToken JWT to verify the alg, sub and iss fields of the header/payload.
 - Amended tests to reflect changes