### PR TITLE
LIME-921: Toggling on in production to test connections

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -210,7 +210,7 @@ Mappings:
       build: "true"
       staging: "true"
       integration: "false"
-      production: "false"
+      production: "true"
 
   FraudCriPepEnabledMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Release to enable crosscore V2 in production

### Why did it change

To enable a connection test before the crosscore switchover

