### PR TITLE
LIME-991 Fix smoke tests via using the wrapper vs gradle directly

### DIFF
--- a/.github/workflows/dailySmokeTest.yml
+++ b/.github/workflows/dailySmokeTest.yml
@@ -39,7 +39,7 @@ jobs:
           coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
           coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
           orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
-        run: cd acceptance-tests && gradle fraudCriSmokeBuild
+        run: cd acceptance-tests && ./gradlew fraudCriSmokeBuild
 
       - name: Get test results history
         uses: actions/checkout@v4

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -57,10 +57,12 @@ dependencies {
 		// testFixturesImplementation
 
 		// acceptance tests Implementation
-		cucumber_version                   : "7.13.0",
-		selenium_version                   : "4.11.0",
+		// Update these together
+		cucumber_version                   : "7.15.0",
+		selenium_version                   : "4.18.1",
 		axe_core_selenium_version          : "4.6.0",
-		webdrivermanager_version           : "5.6.3",
+		webdrivermanager_version           : "5.6.4",
+
 		// acceptance tests testImplementation
 		rest_assured_version               : "5.3.0",
 		cucumber_junit_version             : "7.13.0"

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -176,7 +176,7 @@ public class FraudPageObject extends UniversalSteps {
 
     public void navigateToIPVCoreStub() {
         Driver.get().get(configurationService.getCoreStubUrl(true));
-        waitForTextToAppear(IPV_CORE_STUB);
+        assertPageTitle(IPV_CORE_STUB, true);
     }
 
     public void navigateToFraudCRIOnTestEnv() {
@@ -229,7 +229,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void navigateToResponse(String validOrInvalid) {
-        waitForTextToAppear(CHECK_PAGE_TITLE);
+        assertPageTitle(CHECK_PAGE_TITLE, false);
         checkYourDetailsContinue.click();
         assertURLContains("callback");
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
@@ -240,7 +240,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void whoWeCheckDetailsWith(String page) {
-        waitForTextToAppear(CHECK_PAGE_TITLE);
+        assertPageTitle(CHECK_PAGE_TITLE, false);
         whoWeCheckLink.click();
 
         if ("ThirdParty".equalsIgnoreCase(page)) {
@@ -528,7 +528,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void assertCurrentPageIsFraudCheckPage() {
-        waitForTextToAppear(CHECK_PAGE_TITLE);
+        assertPageTitle(CHECK_PAGE_TITLE, false);
     }
 
     private void assertNbfIsRecentAndExpiryIsNull() throws JsonProcessingException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/ProveYourIdentityFullJourneyPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/ProveYourIdentityFullJourneyPageObject.java
@@ -181,7 +181,7 @@ public class ProveYourIdentityFullJourneyPageObject extends UniversalSteps {
 
         String orchestratorStubUrl = configurationService.getOrchestratorStubUrl();
         Driver.get().get(orchestratorStubUrl);
-        waitForTextToAppear(ORCHESTRATOR_STUB);
+        assertPageTitle(ORCHESTRATOR_STUB, true);
     }
 
     public void clickOnFullJourneyRouteButton() {

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/UniversalSteps.java
@@ -1,33 +1,32 @@
 package gov.di_ipv_fraud.pages;
 
-import gov.di_ipv_fraud.utilities.BrowserUtils;
 import gov.di_ipv_fraud.utilities.Driver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.support.PageFactory;
 
-import java.util.concurrent.TimeUnit;
-
+import static gov.di_ipv_fraud.utilities.BrowserUtils.waitForPageToLoad;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class UniversalSteps {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final int MAX_WAIT_SEC = 10;
 
     public UniversalSteps() {
         PageFactory.initElements(Driver.get(), this);
     }
 
-    public void waitForFiveSeconds() {
-        BrowserUtils.waitForPageToLoad(5);
-    }
+    public void assertPageTitle(String expTitle, boolean fuzzy) {
+        waitForPageToLoad(MAX_WAIT_SEC);
 
-    public void waitForTextToAppear(String text) {
-        String header = Driver.get().getTitle();
-        Driver.get().manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+        String title = Driver.get().getTitle();
 
-        if (header.contains(text)) {
-            assertTrue(Driver.get().getTitle().contains(text));
-        } else {
-            fail("Page Title Does Not Match " + text + "But was " + Driver.get().getTitle());
-        }
+        boolean match = fuzzy ? title.contains(expTitle) : title.equals(expTitle);
+
+        LOGGER.info("Page title: " + title);
+        assertTrue(match);
     }
 
     public void driverClose() {
@@ -35,7 +34,11 @@ public class UniversalSteps {
     }
 
     public void assertURLContains(String expected) {
+        waitForPageToLoad(MAX_WAIT_SEC);
+
         String url = Driver.get().getCurrentUrl();
+
+        LOGGER.info("Page url: " + url);
         assertTrue(url.contains(expected));
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -191,7 +191,7 @@ public class FraudStepDefs extends FraudPageObject {
 
     @Then("Validate User navigation back to core for invalid users")
     public void validate_user_navigation_back_to_core_for_invalid_users() {
-        waitForTextToAppear(IPV_CORE_STUB);
+        assertPageTitle(IPV_CORE_STUB, true);
     }
 
     @When("^I click on Second address$")

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/utilities/Driver.java
@@ -32,19 +32,20 @@ public class Driver {
             switch (browser) {
                 case "chrome":
                     WebDriverManager.chromedriver().setup();
-                    ChromeOptions chromeOptionsLocal = new ChromeOptions();
-                    chromeOptionsLocal.addArguments("--remote-allow-origins=*");
-                    driverPool.set(new ChromeDriver(chromeOptionsLocal));
+                    ChromeOptions chromeOptions1 = new ChromeOptions();
+                    chromeOptions1.addArguments("--remote-allow-origins=*");
+                    driverPool.set(new ChromeDriver(chromeOptions1));
                     break;
                 case "chrome-headless":
                     WebDriverManager.chromedriver().setup();
-                    ChromeOptions chromeOptions = new ChromeOptions().setHeadless(true);
+                    ChromeOptions chromeOptions = new ChromeOptions();
                     chromeOptions.addArguments("--remote-allow-origins=*");
+                    chromeOptions.addArguments("--headless");
+
                     if (ConfigurationReader.noChromeSandbox()) {
                         // no-sandbox is needed for chrome-headless when running in a container due
                         // to restricted syscalls
                         chromeOptions.addArguments("--no-sandbox");
-                        chromeOptions.addArguments("--headless");
                         chromeOptions.addArguments("--whitelisted-ips= ");
                         chromeOptions.addArguments("--disable-dev-shm-usage");
                         chromeOptions.addArguments("--remote-debugging-port=9222");
@@ -61,7 +62,11 @@ public class Driver {
                     break;
                 case "firefox-headless":
                     WebDriverManager.firefoxdriver().setup();
-                    driverPool.set(new FirefoxDriver(new FirefoxOptions().setHeadless(true)));
+
+                    FirefoxOptions firefoxOptions = new FirefoxOptions();
+                    firefoxOptions.addArguments("--headless");
+
+                    driverPool.set(new FirefoxDriver(firefoxOptions));
                     break;
                 case "ie":
                     if (!System.getProperty("os.name").toLowerCase().contains("windows"))

--- a/acceptance-tests/src/test/resources/log4j2.xml
+++ b/acceptance-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=white} %message %n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="ConsoleAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>
+


### PR DESCRIPTION
## Proposed changes

### What changed

Fix smoke tests via using the wrapper vs gradle directly

	- Added note to update the following cucumber_version, selenium_version and webdrivermanager_version together
	- Updated cucumber_version, selenium_version and webdrivermanager_version
	- Fixed race condition for page title assertions via waitForPageToLoad
	- Fix setHeadless removal
	- Added "with gradle-version: wrapper" to setup gradle action

- [LIME-991](https://govukverify.atlassian.net/browse/LIME-991)

[LIME-991]: https://govukverify.atlassian.net/browse/LIME-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ