### PR TITLE
LIME-991 Fix race condition reading VC from dynamic element

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import gov.di_ipv_fraud.service.ConfigurationService;
+import gov.di_ipv_fraud.utilities.BrowserUtils;
 import gov.di_ipv_fraud.utilities.Driver;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
@@ -232,9 +233,12 @@ public class FraudPageObject extends UniversalSteps {
         assertPageTitle(CHECK_PAGE_TITLE, false);
         checkYourDetailsContinue.click();
         assertURLContains("callback");
+
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
+            BrowserUtils.waitForVisibility(errorResponse, 5);
             errorResponse.click();
         } else {
+            BrowserUtils.waitForVisibility(viewResponse, 5);
             viewResponse.click();
         }
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Attempt fix intermittent failures on the VC page by wait for the element that is being clicked to appear in ac tests.

### Why did it change

Mitigate intermittent failures on the element click.

### Issue tracking

- [LIME-991](https://govukverify.atlassian.net/browse/LIME-991)

[LIME-991]: https://govukverify.atlassian.net/browse/LIME-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ