### PR TITLE
LIME-952 Remove CC1 Keystore

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -228,15 +228,6 @@ Mappings:
       integration: "true"
       production: "true"
 
-  # Set as EnvVar on the IdentityCheck Lambda
-  UseTLSKeyStoreEnvVarFeatureToggle:
-    Environment:
-      dev: "false"
-      build: "false"
-      staging: "true"
-      integration: "true"
-      production: "true"
-
 Resources:
 
 ####################################################################
@@ -436,7 +427,6 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-identitycheck"
           ENVIRONMENT: !Ref Environment
-          USE_TLS_KEYSTORE: !FindInMap [ UseTLSKeyStoreEnvVarFeatureToggle, Environment, !Ref Environment ]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -454,20 +444,8 @@ Resources:
             TableName: !Ref ExperianTokenTable
         - DynamoDBWritePolicy:
             TableName: !Ref ExperianTokenTable
-        - Statement:
-            - Sid: ReadParameterStorePolicy
-              Effect: Allow
-              Action:
-                - 'ssm:GetParameter*'
-              Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Environment}/credentialIssuers/fraud*'
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${AWS::StackName}/verifiable-credential/issuer"
-        - Statement:
-            - Sid: ReadSecretsPolicy
-              Effect: Allow
-              Action:
-                - 'secretsmanager:GetSecretValue'
-              Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/credentialIssuers/fraud*'
         - Statement:
             Effect: Allow
             Action:

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
@@ -11,40 +11,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
-
 public class FraudCheckConfigurationService {
-
-    static class KeyStoreParams {
-        private String keyStore;
-        private String keyStorePassword;
-
-        public String getKeyStore() {
-            return keyStore;
-        }
-
-        public void setKeyStore(String keyStore) {
-            this.keyStore = keyStore;
-        }
-
-        public String getKeyStorePassword() {
-            return keyStorePassword;
-        }
-
-        public void setKeyStorePassword(String keyStorePassword) {
-            this.keyStorePassword = keyStorePassword;
-        }
-    }
-
-    private static final String KEY_FORMAT = "/%s/credentialIssuers/fraud/%s";
     private static final String PARAMETER_NAME_FORMAT = "/%s/%s";
 
-    private final String tenantId;
-    private final String endpointUrl;
-    private final String hmacKey;
-    private final String encodedKeyStore;
-    private final String keyStorePassword;
-    private final String thirdPartyId;
     private final String fraudResultTableName;
     private final String contraindicationMappings;
     private final String parameterPrefix;
@@ -80,12 +49,6 @@ public class FraudCheckConfigurationService {
 
         this.clock = Clock.systemUTC();
 
-        this.tenantId = paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiTenantId"));
-        this.endpointUrl =
-                paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiEndpointUrl"));
-        this.hmacKey = secretsProvider.get(String.format(KEY_FORMAT, env, "thirdPartyApiHmacKey"));
-        this.thirdPartyId = paramProvider.get(String.format(KEY_FORMAT, env, "thirdPartyId"));
-
         this.contraindicationMappings =
                 paramProvider.get(getParameterName("contraindicationMappings"));
         this.fraudResultTableName = paramProvider.get(getStackParameterName("FraudTableName"));
@@ -104,42 +67,6 @@ public class FraudCheckConfigurationService {
         // *****************************Feature Toggles*******************************
 
         this.pepEnabled = Boolean.valueOf(paramProvider.get(getStackParameterName("pepEnabled")));
-
-        // *********************************Secrets***********************************
-
-        KeyStoreParams keyStoreParams =
-                secretsProvider
-                        .withTransformation(json)
-                        .get(
-                                String.format(KEY_FORMAT, env, "thirdPartyApiKeyStore"),
-                                KeyStoreParams.class);
-
-        this.encodedKeyStore = keyStoreParams.getKeyStore();
-        this.keyStorePassword = keyStoreParams.getKeyStorePassword();
-    }
-
-    public String getTenantId() {
-        return tenantId;
-    }
-
-    public String getEndpointUrl() {
-        return endpointUrl;
-    }
-
-    public String getHmacKey() {
-        return hmacKey;
-    }
-
-    public String getKeyStorePassword() {
-        return keyStorePassword;
-    }
-
-    public String getEncodedKeyStore() {
-        return encodedKeyStore;
-    }
-
-    public String getThirdPartyId() {
-        return thirdPartyId;
     }
 
     public String getFraudResultTableName() {
@@ -166,16 +93,8 @@ public class FraudCheckConfigurationService {
         return fraudResultItemTtl;
     }
 
-    public void setZeroScoreUcodes(List<String> zeroScoreUcodes) {
-        this.zeroScoreUcodes = zeroScoreUcodes;
-    }
-
     public Integer getNoFileFoundThreshold() {
         return noFileFoundThreshold;
-    }
-
-    public void setNoFileFoundThreshold(Integer noFileFoundThreshold) {
-        this.noFileFoundThreshold = noFileFoundThreshold;
     }
 
     public long getFraudResultItemExpirationEpoch() {
@@ -183,11 +102,11 @@ public class FraudCheckConfigurationService {
     }
 
     private String getParameterName(String parameterName) {
-        return String.format("/%s/%s", parameterPrefix, parameterName);
+        return String.format(PARAMETER_NAME_FORMAT, parameterPrefix, parameterName);
     }
 
     private String getStackParameterName(String parameterName) {
-        return String.format("/%s/%s", stackParameterPrefix, parameterName);
+        return String.format(PARAMETER_NAME_FORMAT, stackParameterPrefix, parameterName);
     }
 
     private String getCommonParameterName(String parameterName) {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
@@ -43,20 +42,6 @@ class FraudCheckConfigurationServiceTest {
         environmentVariables.set("PARAMETER_PREFIX", PARAMETER_PREFIX);
         environmentVariables.set("AWS_STACK_NAME", AWS_STACK_NAME);
         environmentVariables.set("COMMON_PARAMETER_NAME_PREFIX", COMMON_PARAMETER_NAME_PREFIX);
-
-        String tenantIdKey = "thirdPartyApiTenantId";
-        String tenantIdValue = "test-tenant-id";
-
-        String hmacKey = "thirdPartyApiHmacKey";
-        String testHmacKeyValue = "test-key";
-
-        String endpointKey = "thirdPartyApiEndpointUrl";
-        String endpointValue = "test-endpoint";
-
-        String thirdPartyIdKey = "thirdPartyId";
-        String thirdPartyIdValue = "third-party-id";
-
-        String keyStoreKey = "thirdPartyApiKeyStore";
 
         String fraudTableNameKey = "FraudTableName";
         String fraudTableNameValue = "FraudTableValue";
@@ -103,18 +88,6 @@ class FraudCheckConfigurationServiceTest {
 
         String crosscoreV2TokenIssuerKey = "CrosscoreV2/tokenIssuer";
         String crosscoreV2TokenIssuerValue = "crosscoreV2TokenIssuer";
-
-        FraudCheckConfigurationService.KeyStoreParams testKeyStoreParams =
-                new FraudCheckConfigurationService.KeyStoreParams();
-        testKeyStoreParams.setKeyStore("keystore");
-        testKeyStoreParams.setKeyStorePassword("pwd");
-
-        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, tenantIdKey)))
-                .thenReturn(tenantIdValue);
-        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, endpointKey)))
-                .thenReturn(endpointValue);
-        when(mockParamProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, thirdPartyIdKey)))
-                .thenReturn(thirdPartyIdValue);
 
         when(mockParamProvider.get(
                         String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, fraudTableNameKey)))
@@ -187,23 +160,12 @@ class FraudCheckConfigurationServiceTest {
                 .thenReturn(crosscoreV2TokenIssuerValue);
 
         // ***************************************************************************************************
-        when(mockSecretsProvider.get(String.format(KEY_FORMAT, ENVIRONMENT, hmacKey)))
-                .thenReturn(testHmacKeyValue);
-        when(mockSecretsProvider.get(
-                        String.format(KEY_FORMAT, ENVIRONMENT, keyStoreKey),
-                        FraudCheckConfigurationService.KeyStoreParams.class))
-                .thenReturn(testKeyStoreParams);
-        when(mockSecretsProvider.withTransformation(json)).thenReturn(mockSecretsProvider);
 
         FraudCheckConfigurationService fraudCheckConfigurationService =
                 new FraudCheckConfigurationService(
                         mockSecretsProvider, mockParamProvider, ENVIRONMENT);
 
         assertNotNull(fraudCheckConfigurationService);
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, tenantIdKey));
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, endpointKey));
-        verify(mockParamProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, thirdPartyIdKey));
-        verify(mockSecretsProvider).get(String.format(KEY_FORMAT, ENVIRONMENT, hmacKey));
 
         verify(mockParamProvider)
                 .get(String.format(STACK_PARAMETER_FORMAT, AWS_STACK_NAME, fraudTableNameKey));
@@ -252,21 +214,6 @@ class FraudCheckConfigurationServiceTest {
                                 STACK_PARAMETER_FORMAT, AWS_STACK_NAME, experianTokenTableNameKey));
 
         // ***************************************************************************************************
-
-        verify(mockSecretsProvider)
-                .get(
-                        String.format(KEY_FORMAT, ENVIRONMENT, keyStoreKey),
-                        FraudCheckConfigurationService.KeyStoreParams.class);
-        assertEquals(
-                testKeyStoreParams.getKeyStore(),
-                fraudCheckConfigurationService.getEncodedKeyStore());
-        assertEquals(
-                testKeyStoreParams.getKeyStorePassword(),
-                fraudCheckConfigurationService.getKeyStorePassword());
-        assertEquals(testHmacKeyValue, fraudCheckConfigurationService.getHmacKey());
-        assertEquals(thirdPartyIdValue, fraudCheckConfigurationService.getThirdPartyId());
-        assertEquals(endpointValue, fraudCheckConfigurationService.getEndpointUrl());
-        assertEquals(tenantIdValue, fraudCheckConfigurationService.getTenantId());
 
         assertEquals(fraudTableNameValue, fraudCheckConfigurationService.getFraudResultTableName());
         assertEquals(

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/ServiceFactoryTest.java
@@ -2,34 +2,18 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.util.Base64;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@ExtendWith(SystemStubsExtension.class)
 class ServiceFactoryTest {
-
-    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private static final String TEST_TOKEN_CLIENTID = "testTokenClientIdValue";
     private static final String TEST_TOKEN_ENDPOINT = "testTokenEndpointValue";
@@ -49,24 +33,8 @@ class ServiceFactoryTest {
 
     @Mock private EventProbe mockEventProbe;
 
-    @ParameterizedTest
-    @CsvSource({"true", "false"})
-    void shouldCreateIdentityVerificationService(boolean useTlsKeyStore)
-            throws NoSuchAlgorithmException, HttpException, KeyStoreException, CertificateException,
-                    IOException {
-
-        environmentVariables.set("USE_TLS_KEYSTORE", useTlsKeyStore);
-
-        if (useTlsKeyStore) {
-            // Test needs a real keystore as it is auto mapped from strings
-            final char[] unitTestKeyStorePassword = UUID.randomUUID().toString().toCharArray();
-            final String testKeyStore = generateUnitTestKeyStore(unitTestKeyStorePassword);
-            final String testKeyStorePassword = new String(unitTestKeyStorePassword);
-
-            when(mockFraudCheckConfigurationService.getEncodedKeyStore()).thenReturn(testKeyStore);
-            when(mockFraudCheckConfigurationService.getKeyStorePassword())
-                    .thenReturn(testKeyStorePassword);
-        }
+    @Test
+    void shouldCreateIdentityVerificationService() throws HttpException {
 
         when(mockCrosscoreV2Configuration.getTokenEndpoint()).thenReturn(TEST_TOKEN_ENDPOINT);
         when(mockCrosscoreV2Configuration.getClientId()).thenReturn(TEST_TOKEN_CLIENTID);
@@ -91,19 +59,5 @@ class ServiceFactoryTest {
                 serviceFactory.getIdentityVerificationService();
 
         assertNotNull(identityVerificationService);
-    }
-
-    private String generateUnitTestKeyStore(char[] unitTestKeyStorePassword)
-            throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
-
-        KeyStore unitTestkeyStore = KeyStore.getInstance("pkcs12");
-        unitTestkeyStore.load(null, unitTestKeyStorePassword); // New KeyStore
-
-        ByteArrayOutputStream bao = new ByteArrayOutputStream();
-        unitTestkeyStore.store(bao, unitTestKeyStorePassword);
-
-        byte[] base64 = Base64.getEncoder().encode(bao.toByteArray());
-
-        return new String(base64);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

No longer add the cc1 keystore to the http client -
- note ssl context is still used and "TLSv1.2" requested.

Remove permissions for the environment CC1 parameters and secrets.

### Why did it change

Part of the clean up of remaining CC1 parameters and secrets.

### Issue tracking

- [LIME-952](https://govukverify.atlassian.net/browse/LIME-952)

[LIME-952]: https://govukverify.atlassian.net/browse/LIME-952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ