### PR TITLE
LIME-1045 (AC Test) Update the 302 error message assert to match the oauth error message now set by the API

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -312,7 +312,7 @@ public class FraudPageObject extends UniversalSteps {
     }
 
     public void jsonErrorResponse(String testStatusCode) throws JsonProcessingException {
-        String testErrorDescription = "general error";
+        String testErrorDescription = "Unexpected server error";
         JsonNode insideError = getVCFromJson("errorObject");
         LOGGER.info("insideError = " + insideError);
         JsonNode errorDescription = insideError.get("description");


### PR DESCRIPTION
## Proposed changes

### What changed

Update the 302 error message assert to match the oauth error message now set by the API

### Why did it change

Previously this was not set and relied on a fall back default in common-express.

### Issue tracking


- [LIME-1045](https://govukverify.atlassian.net/browse/LIME-1045)


[LIME-1045]: https://govukverify.atlassian.net/browse/LIME-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ