### PR TITLE
LIME-967 - Updating configuration to handle routing to 3rd party base…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,23 @@ Any time you wish to deploy, run:
 The command to run is:
 
 `aws-vault exec fraud-dev -- sam delete --config-env dev --stack-name <unique-stack-name>`
+
+## TestData Strategy
+
+For testing purposes, this CRI has the ability to route users requests to either
+a real 3rd Party UAT instance of the service OR route users requests to an internally 
+managed, stubbed version of the 3rd party service.
+
+Routing for the above is dictated by the client ID sent to the CRI from IPVCore/stubs. For lower
+environments there is an IPV core stub that is configured to for routing CRIs to 3rd party stubs and another 
+IPV core stub that is configured for routing CRIs to the 3rd party UAT environment. 
+
+For testing purposes if you wish to route to the stubbed version of the 3rd party then use the following 
+core stub URL - https://cri.core.stubs.account.gov.uk/
+If you wish to route to the real 3rd partys UAT instance of the service use the following 
+core stub url - https://cri-3rdparty.core.stubs.account.gov.uk/
+
+Additional details on these stubs can be found on this confluence page - 
+https://govukverify.atlassian.net/wiki/spaces/OJ/pages/3147333723/Stubs+for+testing+journeys
+
+

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -484,6 +484,9 @@ Resources:
                 - !Sub
                   - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/noFileFoundThreshold"
                   - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
+                - !Sub
+                  - "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${PREFIX}/testStrategy/noFileFoundThreshold"
+                  - PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/FraudTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pepEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/CrosscoreV2/tokenTableName"

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/TestStrategyClientId.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/TestStrategyClientId.java
@@ -1,0 +1,8 @@
+package uk.gov.di.ipv.cri.fraud.api.gateway.dto.request;
+
+public enum TestStrategyClientId {
+    STUB,
+    UAT,
+    LIVE,
+    NO_CHANGE
+}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/TestStrategyClientId.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/dto/request/TestStrategyClientId.java
@@ -1,8 +1,0 @@
-package uk.gov.di.ipv.cri.fraud.api.gateway.dto.request;
-
-public enum TestStrategyClientId {
-    STUB,
-    UAT,
-    LIVE,
-    NO_CHANGE
-}

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpException;
 import org.apache.logging.log4j.LogManager;
@@ -86,7 +87,7 @@ public class FraudHandler
     private boolean functionInitMetricCaptured = false;
 
     @ExcludeFromGeneratedCoverageReport
-    public FraudHandler() throws HttpException {
+    public FraudHandler() throws HttpException, JsonProcessingException {
         ServiceFactory serviceFactory = new ServiceFactory();
 
         FraudCheckConfigurationService fraudCheckConfigurationServiceNotYetAssigned =
@@ -157,7 +158,7 @@ public class FraudHandler
     }
 
     private FraudCheckConfigurationService createFraudCheckConfigurationService(
-            ServiceFactory serviceFactory) {
+            ServiceFactory serviceFactory) throws JsonProcessingException {
 
         ParameterStoreService parameterStoreService = serviceFactory.getParameterStoreService();
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.HttpException;
 import org.apache.logging.log4j.LogManager;
@@ -161,8 +162,9 @@ public class FraudHandler
             ServiceFactory serviceFactory) throws JsonProcessingException {
 
         ParameterStoreService parameterStoreService = serviceFactory.getParameterStoreService();
+        ObjectMapper objectMapper = serviceFactory.getObjectMapper();
 
-        return new FraudCheckConfigurationService(parameterStoreService);
+        return new FraudCheckConfigurationService(parameterStoreService, objectMapper);
     }
 
     @Override

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
@@ -1,15 +1,15 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import uk.gov.di.ipv.cri.fraud.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.fraud.library.service.parameterstore.ParameterPrefix;
 
-import java.net.URI;
 import java.util.Map;
 
 @Getter
 public class CrosscoreV2Configuration {
-
     public static final String CC2_PARAMETER_PATH = "CrosscoreV2";
 
     public static final String TOKEN_TABLE_NAME_PARAMETER_KEY = "CrosscoreV2/tokenTableName";
@@ -24,6 +24,14 @@ public class CrosscoreV2Configuration {
 
     public static final String CC2_ENDPOINT_PARAMETER_KEY = "endpointUrl";
     public static final String CC2_TENANT_ID_PARAMETER_KEY = "tenantId";
+
+    // TestDataStrategyUpdates
+    public static final String CC2_TEST_STRATEGY_ENDPOINT_PARAMETER_KEY =
+            "testStrategy/endpointUrl";
+    public static final String TEST_STRATEGY_TOKEN_END_POINT_PARAMETER_KEY =
+            "testStrategy/tokenEndpoint";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     // Dynamo
     private final String tokenTableName;
@@ -42,14 +50,16 @@ public class CrosscoreV2Configuration {
 
     // Token Response Validation
     private final String tokenIssuer;
-
-    // Crosscore Endpoint
-    private final URI endpointUri;
-
+    private final String endpointUri;
     // Crosscore Header
     private final String tenantId;
 
-    public CrosscoreV2Configuration(ParameterStoreService parameterStoreService) {
+    // TestDataStrategyUpdates
+    private final Map<String, String> endpointURIs;
+    private final Map<String, String> tokenEndpointURIs;
+
+    public CrosscoreV2Configuration(ParameterStoreService parameterStoreService)
+            throws JsonProcessingException {
 
         Map<String, String> ccV2ParameterMap =
                 parameterStoreService.getAllParametersFromPath(
@@ -72,7 +82,22 @@ public class CrosscoreV2Configuration {
 
         this.tokenIssuer = ccV2ParameterMap.get(TOKEN_ISSUER_PARAMETER_KEY);
 
-        this.endpointUri = URI.create(ccV2ParameterMap.get(CC2_ENDPOINT_PARAMETER_KEY));
+        this.endpointUri = ccV2ParameterMap.get(CC2_ENDPOINT_PARAMETER_KEY);
         this.tenantId = ccV2ParameterMap.get(CC2_TENANT_ID_PARAMETER_KEY);
+
+        // TestDataStrategyConfigurations
+        this.endpointURIs =
+                constructParameterMap(
+                        ccV2ParameterMap.get(CC2_TEST_STRATEGY_ENDPOINT_PARAMETER_KEY));
+        this.tokenEndpointURIs =
+                constructParameterMap(
+                        ccV2ParameterMap.get(TEST_STRATEGY_TOKEN_END_POINT_PARAMETER_KEY));
+    }
+
+    private Map<String, String> constructParameterMap(String parameterValue)
+            throws JsonProcessingException {
+        Map<String, String> parameterValueMap = objectMapper.readValue(parameterValue, Map.class);
+
+        return parameterValueMap;
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java
@@ -96,8 +96,6 @@ public class CrosscoreV2Configuration {
 
     private Map<String, String> constructParameterMap(String parameterValue)
             throws JsonProcessingException {
-        Map<String, String> parameterValueMap = objectMapper.readValue(parameterValue, Map.class);
-
-        return parameterValueMap;
+        return objectMapper.readValue(parameterValue, Map.class);
     }
 }

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.di.ipv.cri.fraud.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.fraud.library.service.parameterstore.ParameterPrefix;
 
@@ -19,7 +20,8 @@ public class FraudCheckConfigurationService {
 
     private final CrosscoreV2Configuration crosscoreV2Configuration;
 
-    public FraudCheckConfigurationService(ParameterStoreService parameterStoreService) {
+    public FraudCheckConfigurationService(ParameterStoreService parameterStoreService)
+            throws JsonProcessingException {
         // ****************************  Environment Parameters ****************************
 
         // None

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculator.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.cri.fraud.api.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -10,16 +11,17 @@ import java.util.List;
 public class IdentityScoreCalculator {
 
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private FraudCheckConfigurationService fraudCheckConfigurationService;
     private List<String> zeroScoreUcodes;
-    private Integer noFileFoundThreshold = 0;
 
     public IdentityScoreCalculator(FraudCheckConfigurationService fraudCheckConfigurationService) {
         zeroScoreUcodes = fraudCheckConfigurationService.getZeroScoreUcodes();
-        noFileFoundThreshold = fraudCheckConfigurationService.getNoFileFoundThreshold();
+        this.fraudCheckConfigurationService = fraudCheckConfigurationService;
     }
 
     public int calculateIdentityScoreAfterFraudCheck(
-            FraudCheckResult fraudCheckResult, boolean checkSuccess) {
+            FraudCheckResult fraudCheckResult, boolean checkSuccess, Strategy strategy) {
 
         if (checkSuccess) {
             Integer decisionScore = Integer.valueOf(fraudCheckResult.getDecisionScore());
@@ -32,7 +34,7 @@ public class IdentityScoreCalculator {
                 }
             }
 
-            if (decisionScore <= noFileFoundThreshold) {
+            if (decisionScore <= fraudCheckConfigurationService.getNoFileFoundThreshold(strategy)) {
                 LOGGER.info(
                         "Decision score was below the file found threshold they cannot score higher than one");
                 return 1;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -18,10 +18,10 @@ import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyPepGateway;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.library.domain.CheckType;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 import uk.gov.di.ipv.cri.fraud.library.service.ServiceFactory;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -51,19 +51,6 @@ public class IdentityVerificationService {
             "FraudCheckResult had no error message.";
     private static final String ERROR_PEP_CHECK_RESULT_NO_ERR_MSG =
             "PepCheckResult had no error message.";
-
-    // Below Values pertain to all the possible clientIDs that can be passed to the CRI from
-    // different versions of ipvCore/stubs
-    // One set of clientIds used in the configuration of stubs that route CRIs to 3rd parties
-    // (UAT/LIVE)
-    // + One set of clientIds for the configuration of stubs that route CRIs to internally managed
-    // stubbed 3rd parties
-    private static final String UAT_3rdPARTY_CLIENTID_BUILD = "ipv-core-stub-aws-build_3rdparty";
-    private static final String UAT_3rdPARTY_CLIENTID_PROD = "ipv-core-stub-aws-prod_3rdparty";
-    private static final String STUB_CLIENTID_BUILD = "ipv-core-stub-aws-build";
-    private static final String STUB_CLIENTID_PROD = "ipv-core-stub-aws-prod";
-    private static final String LIVE_CLIENTID = "ipv-core";
-    private static final String LIVE_CLIENTID_PRE_PROD = "ipv-core-stub-pre-prod-aws-build";
 
     private final ObjectMapper objectMapper;
 
@@ -129,41 +116,14 @@ public class IdentityVerificationService {
         LOGGER.info("PersonIdentity validated");
         eventProbe.counterMetric(PERSON_DETAILS_VALIDATION_PASS);
 
-        TestStrategyClientId thirdPartyRouting = TestStrategyClientId.NO_CHANGE;
+        String clientId = sessionItem.getClientId();
+        Strategy strategy = Strategy.fromClientIdString(sessionItem.getClientId());
 
-        String testStrategyClientId = sessionItem.getClientId();
-        switch (testStrategyClientId) {
-            case STUB_CLIENTID_PROD:
-                thirdPartyRouting = TestStrategyClientId.STUB;
-            case STUB_CLIENTID_BUILD:
-                thirdPartyRouting = TestStrategyClientId.STUB;
-                break;
-            case UAT_3rdPARTY_CLIENTID_BUILD:
-                thirdPartyRouting = TestStrategyClientId.UAT;
-            case UAT_3rdPARTY_CLIENTID_PROD:
-                thirdPartyRouting = TestStrategyClientId.UAT;
-                break;
-            case LIVE_CLIENTID:
-                thirdPartyRouting = TestStrategyClientId.LIVE;
-            case LIVE_CLIENTID_PRE_PROD:
-                thirdPartyRouting = TestStrategyClientId.LIVE;
-                break;
-            default:
-                // thirdPartyRouting is noChange by default (falls back to default Routing if
-                // ClientId is not recognised)
-                LOGGER.warn(
-                        "Unknown client id {} defaulting to pre test strategy params",
-                        testStrategyClientId);
-                thirdPartyRouting = TestStrategyClientId.NO_CHANGE;
-        }
-        LOGGER.info(
-                "IPV Core Client Id {}, Routing set to {}",
-                testStrategyClientId,
-                thirdPartyRouting);
+        LOGGER.info("IPV Core Client Id {}, Routing set to {}", clientId, strategy);
 
-        String token = tokenRequestService.requestToken(false, thirdPartyRouting);
+        String token = tokenRequestService.requestToken(false, strategy);
         IdentityVerificationResult fraudIdentityVerificationResult =
-                fraudCheckStep(personIdentity, token, thirdPartyRouting);
+                fraudCheckStep(personIdentity, token, strategy);
         IdentityVerificationResult pepIdentityVerificationResult = new IdentityVerificationResult();
 
         boolean pepValidToPerform =
@@ -176,7 +136,7 @@ public class IdentityVerificationService {
                             personIdentity,
                             fraudIdentityVerificationResult.getIdentityCheckScore(),
                             token,
-                            thirdPartyRouting);
+                            strategy);
         }
 
         int identityCheckScore =
@@ -241,15 +201,14 @@ public class IdentityVerificationService {
     }
 
     public IdentityVerificationResult fraudCheckStep(
-            PersonIdentity personIdentity, String token, TestStrategyClientId thirdPartyRouting)
+            PersonIdentity personIdentity, String token, Strategy strategy)
             throws JsonProcessingException {
         IdentityVerificationResult identityVerificationResult = new IdentityVerificationResult();
         // Requests split into two try blocks to differentiate tech failures in fraud from pep
         FraudCheckResult fraudCheckResult;
         try {
             fraudCheckResult =
-                    thirdPartyFraudGateway.performFraudCheck(
-                            personIdentity, token, thirdPartyRouting);
+                    thirdPartyFraudGateway.performFraudCheck(personIdentity, token, strategy);
         } catch (Exception e) {
             LOGGER.error(ERROR_MSG_CONTEXT, e);
             eventProbe.counterMetric(FRAUD_CHECK_REQUEST_FAILED);
@@ -325,7 +284,7 @@ public class IdentityVerificationService {
 
         int fraudIdentityCheckScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, true);
+                        fraudCheckResult, true, strategy);
         int activityHistoryScore =
                 activityHistoryScoreCalculator.calculateActivityHistoryScore(
                         fraudCheckResult.getOldestRecordDateInMonths());
@@ -355,7 +314,7 @@ public class IdentityVerificationService {
         }
         // else add ACTIVITY_HISTORY_CHECK to checksFailed
 
-        if (decisionScore <= fraudCheckConfigurationService.getNoFileFoundThreshold()) {
+        if (decisionScore <= fraudCheckConfigurationService.getNoFileFoundThreshold(strategy)) {
 
             // Fraud Checks that have failed if decisionScore <= NoFileFoundThreshold
             checksFailed.add(CheckType.MORTALITY_CHECK.toString());
@@ -401,10 +360,7 @@ public class IdentityVerificationService {
     }
 
     public IdentityVerificationResult pepCheckStep(
-            PersonIdentity personIdentity,
-            int currentScore,
-            String token,
-            TestStrategyClientId thirdPartyRouting)
+            PersonIdentity personIdentity, int currentScore, String token, Strategy strategy)
             throws JsonProcessingException {
 
         IdentityVerificationResult identityVerificationResult = new IdentityVerificationResult();
@@ -414,8 +370,7 @@ public class IdentityVerificationService {
         PepCheckResult pepCheckResult = null;
 
         try {
-            pepCheckResult =
-                    thirdPartyPepGateway.performPepCheck(personIdentity, token, thirdPartyRouting);
+            pepCheckResult = thirdPartyPepGateway.performPepCheck(personIdentity, token, strategy);
         } catch (Exception e) {
             // Pep check can completely fail and result returned based on fraud check alone
             LOGGER.error(ERROR_MSG_CONTEXT, e);

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.RequestHeaderKeys;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TokenRequestPayload;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.TokenResponse;
 import uk.gov.di.ipv.cri.fraud.api.persistence.item.TokenItem;
@@ -46,7 +47,6 @@ public class TokenRequestService {
 
     private final String clientSecret;
     private final String clientId;
-    private final URI requestURI;
     private final String username;
     private final String password;
     private final String userDomain;
@@ -92,7 +92,6 @@ public class TokenRequestService {
 
         this.clientSecret = crosscoreV2Configuration.getClientSecret();
         this.clientId = crosscoreV2Configuration.getClientId();
-        this.requestURI = URI.create(crosscoreV2Configuration.getTokenEndpoint());
         this.username = crosscoreV2Configuration.getUsername();
         this.password = crosscoreV2Configuration.getPassword();
         this.userDomain = crosscoreV2Configuration.getUserDomain();
@@ -106,7 +105,9 @@ public class TokenRequestService {
         this.httpRetryStatusConfig = new TokenHttpRetryStatusConfig();
     }
 
-    public String requestToken(boolean alwaysRequestNewToken) throws OAuthErrorResponseException {
+    public String requestToken(
+            boolean alwaysRequestNewToken, TestStrategyClientId thirdPartyRouting)
+            throws OAuthErrorResponseException {
         LOGGER.info("Checking Table {} for existing cached token", tokenTableName);
 
         TokenItem tokenItem = getTokenItemFromTable();
@@ -131,7 +132,7 @@ public class TokenRequestService {
         // Request an Access Token
         if (newTokenRequest) {
             try {
-                TokenResponse newTokenResponse = performNewTokenRequest();
+                TokenResponse newTokenResponse = performNewTokenRequest(thirdPartyRouting);
                 LOGGER.debug("Saving Token {}", newTokenResponse.getAccessToken());
 
                 tokenItem = new TokenItem(newTokenResponse.getAccessToken());
@@ -168,7 +169,9 @@ public class TokenRequestService {
         return tokenItem.getTokenValue();
     }
 
-    private TokenResponse performNewTokenRequest() throws OAuthErrorResponseException {
+    private TokenResponse performNewTokenRequest(TestStrategyClientId thirdPartyRouting)
+            throws OAuthErrorResponseException {
+        URI requestURI = selectRequestURI(thirdPartyRouting);
 
         final String correlationId = UUID.randomUUID().toString();
         LOGGER.info("{} Correlation Id {}", REQUEST_NAME, correlationId);
@@ -326,6 +329,32 @@ public class TokenRequestService {
         LOGGER.info(
                 "Token cached - expires {} UTC",
                 Instant.ofEpochSecond(ttlSeconds).atZone(ZoneId.systemDefault()).toLocalDateTime());
+    }
+
+    private URI selectRequestURI(TestStrategyClientId thirdPartyRouting) {
+        URI requestUri = null;
+        switch (thirdPartyRouting) {
+            case STUB:
+                requestUri =
+                        URI.create(crosscoreV2Configuration.getTokenEndpointURIs().get("STUB"));
+                break;
+            case UAT:
+                requestUri = URI.create(crosscoreV2Configuration.getTokenEndpointURIs().get("UAT"));
+                break;
+            case LIVE:
+                requestUri =
+                        URI.create(crosscoreV2Configuration.getTokenEndpointURIs().get("LIVE"));
+                break;
+            case NO_CHANGE:
+                requestUri = URI.create(crosscoreV2Configuration.getTokenEndpoint());
+                break;
+            default:
+                LOGGER.warn(
+                        "could not select valid tokenRequestUri falling back to environment default");
+                requestUri = URI.create(crosscoreV2Configuration.getTokenEndpoint());
+                break;
+        }
+        return requestUri;
     }
 
     public boolean isTokenNearExpiration(TokenItem tokenItem, long expiryWindow) {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
 import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckConfigurationService;
@@ -26,6 +25,7 @@ import uk.gov.di.ipv.cri.fraud.api.service.PepCheckHttpRetryStatusConfig;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 import uk.gov.di.ipv.cri.fraud.library.service.HttpRetryer;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 import uk.gov.di.ipv.cri.fraud.library.util.HTTPReply;
 
 import java.io.IOException;
@@ -175,7 +175,7 @@ class ThirdPartyFraudGatewayComponentTest {
 
         PepCheckResult actualPepCheckResult =
                 thirdPartyPepGateway.performPepCheck(
-                        personIdentity, "testAccessTokenValue", TestStrategyClientId.NO_CHANGE);
+                        personIdentity, "testAccessTokenValue", Strategy.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
 import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckConfigurationService;
@@ -84,6 +85,8 @@ class ThirdPartyFraudGatewayComponentTest {
         when(mockFraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2ConfigurationService);
         when(mockCrosscoreV2ConfigurationService.getTenantId()).thenReturn("123456");
+        when(mockCrosscoreV2ConfigurationService.getTokenEndpoint()).thenReturn("http://localhost");
+        when(mockCrosscoreV2ConfigurationService.getEndpointUri()).thenReturn("http://localhost");
         when(mockRequestMapper.mapPEPPersonIdentity(personIdentity, "123456"))
                 .thenReturn(testApiRequest);
 
@@ -171,7 +174,8 @@ class ThirdPartyFraudGatewayComponentTest {
                 .thenReturn(testPepCheckResult);
 
         PepCheckResult actualPepCheckResult =
-                thirdPartyPepGateway.performPepCheck(personIdentity, "testAccessTokenValue");
+                thirdPartyPepGateway.performPepCheck(
+                        personIdentity, "testAccessTokenValue", TestStrategyClientId.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.IdentityVerificationRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.IdentityVerificationResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
 import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckConfigurationService;
@@ -94,6 +95,7 @@ class ThirdPartyFraudGatewayTest {
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
         when(mockRequestMapper.mapPersonIdentity(personIdentity, "12345"))
                 .thenReturn(testApiRequest);
 
@@ -114,7 +116,8 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(testFraudCheckResult);
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity, TEST_ACCESS_TOKEN);
+                thirdPartyFraudGateway.performFraudCheck(
+                        personIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
@@ -161,6 +164,7 @@ class ThirdPartyFraudGatewayTest {
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
 
         when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
         ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor =
@@ -188,7 +192,9 @@ class ThirdPartyFraudGatewayTest {
                         OAuthErrorResponseException.class,
                         () ->
                                 thirdPartyFraudGateway.performFraudCheck(
-                                        personIdentity, TEST_ACCESS_TOKEN),
+                                        personIdentity,
+                                        TEST_ACCESS_TOKEN,
+                                        TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -240,6 +246,7 @@ class ThirdPartyFraudGatewayTest {
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
 
         when(this.mockObjectMapper.writeValueAsString(testApiRequest)).thenReturn(testRequestBody);
 
@@ -253,7 +260,8 @@ class ThirdPartyFraudGatewayTest {
                 .thenReturn(new HTTPReply(errorStatus, null, TEST_API_RESPONSE_BODY));
 
         FraudCheckResult actualFraudCheckResult =
-                thirdPartyFraudGateway.performFraudCheck(personIdentity, TEST_ACCESS_TOKEN);
+                thirdPartyFraudGateway.performFraudCheck(
+                        personIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentity;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.PEPRequest;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.PEPResponse;
 import uk.gov.di.ipv.cri.fraud.api.service.CrosscoreV2Configuration;
 import uk.gov.di.ipv.cri.fraud.api.service.FraudCheckConfigurationService;
@@ -62,6 +63,12 @@ class ThirdPartyPepGatewayTest {
     private static final String TEST_ENDPOINT_URL = "https://test-endpoint.co.uk";
     private static final String TEST_ACCESS_TOKEN = "testTokenValue";
     private static final String HMAC_OF_REQUEST_BODY = "hmac-of-request-body";
+    String stubExperianEndpointValue = "http://localhostStub";
+    String UatExperianEndpointValue = "http://localhostUat";
+    String LiveExperianEndpointValue = "http://localhostLive";
+    String stubTokenEndpointValue = "http://localhostStub";
+    String UatTokenEndpointValue = "http://localhostUat";
+    String LiveTokenEndpointValue = "http://localhostLive";
     private ThirdPartyPepGateway thirdPartyPepGateway;
 
     @Mock private HttpRetryer mockHttpRetryer;
@@ -97,6 +104,7 @@ class ThirdPartyPepGatewayTest {
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
         when(mockRequestMapper.mapPEPPersonIdentity(personIdentity, "12345"))
                 .thenReturn(testApiRequest);
 
@@ -117,7 +125,8 @@ class ThirdPartyPepGatewayTest {
                 .thenReturn(testPepCheckResult);
 
         PepCheckResult actualPepCheckResult =
-                thirdPartyPepGateway.performPepCheck(personIdentity, TEST_ACCESS_TOKEN);
+                thirdPartyPepGateway.performPepCheck(
+                        personIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe
@@ -161,7 +170,9 @@ class ThirdPartyPepGatewayTest {
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+
         when(mockRequestMapper.mapPEPPersonIdentity(personIdentity, "12345"))
                 .thenReturn(testApiRequest);
 
@@ -191,7 +202,9 @@ class ThirdPartyPepGatewayTest {
                         OAuthErrorResponseException.class,
                         () ->
                                 thirdPartyPepGateway.performPepCheck(
-                                        personIdentity, TEST_ACCESS_TOKEN),
+                                        personIdentity,
+                                        TEST_ACCESS_TOKEN,
+                                        TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         assertEquals(expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
@@ -241,6 +254,8 @@ class ThirdPartyPepGatewayTest {
         when(fraudCheckConfigurationService.getCrosscoreV2Configuration())
                 .thenReturn(mockCrosscoreV2Configuration);
         when(mockCrosscoreV2Configuration.getTenantId()).thenReturn("12345");
+        when(mockCrosscoreV2Configuration.getEndpointUri()).thenReturn("http://localhost");
+
         when(mockRequestMapper.mapPEPPersonIdentity(personIdentity, "12345"))
                 .thenReturn(testApiRequest);
 
@@ -256,7 +271,8 @@ class ThirdPartyPepGatewayTest {
                 .thenReturn(new HTTPReply(errorStatus, null, TEST_API_RESPONSE_BODY));
 
         PepCheckResult actualPepCheckResult =
-                thirdPartyPepGateway.performPepCheck(personIdentity, TEST_ACCESS_TOKEN);
+                thirdPartyPepGateway.performPepCheck(
+                        personIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
 
         InOrder inOrderMockEventProbe = inOrder(mockEventProbe);
         inOrderMockEventProbe

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java
@@ -1,12 +1,14 @@
 package uk.gov.di.ipv.cri.fraud.api.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.fraud.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.fraud.library.service.parameterstore.ParameterPrefix;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -150,7 +152,7 @@ class FraudCheckConfigurationServiceTest {
 
         // Creation
         FraudCheckConfigurationService fraudCheckConfigurationService =
-                new FraudCheckConfigurationService(mockParameterStoreService);
+                new FraudCheckConfigurationService(mockParameterStoreService, new ObjectMapper());
 
         assertNotNull(fraudCheckConfigurationService);
 
@@ -161,7 +163,7 @@ class FraudCheckConfigurationServiceTest {
         assertEquals(zeroScoreUcodesListValue, fraudCheckConfigurationService.getZeroScoreUcodes());
         assertEquals(
                 noFileFoundThresholdValue,
-                fraudCheckConfigurationService.getNoFileFoundThreshold());
+                fraudCheckConfigurationService.getNoFileFoundThreshold(Strategy.NO_CHANGE));
 
         // CC2
         verify(mockParameterStoreService)

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 
 import java.util.List;
 
@@ -26,13 +27,14 @@ class IdentityScoreCalculatorTest {
         fraudCheckResult.setTransactionId("123456789");
 
         when(mockFraudCheckConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
-        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold(Strategy.NO_CHANGE))
+                .thenReturn(35);
         this.identityScoreCalculator =
                 new IdentityScoreCalculator(mockFraudCheckConfigurationService);
 
         int identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, true);
+                        fraudCheckResult, true, Strategy.NO_CHANGE);
         identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterPEPCheck(identityScore, true);
 
@@ -48,13 +50,13 @@ class IdentityScoreCalculatorTest {
         fraudCheckResult.setTransactionId("123456789");
 
         when(mockFraudCheckConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
-        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+
         this.identityScoreCalculator =
                 new IdentityScoreCalculator(mockFraudCheckConfigurationService);
 
         int identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, true);
+                        fraudCheckResult, true, Strategy.NO_CHANGE);
         identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterPEPCheck(identityScore, true);
         assertEquals(0, identityScore);
@@ -69,13 +71,14 @@ class IdentityScoreCalculatorTest {
         fraudCheckResult.setTransactionId("123456789");
 
         when(mockFraudCheckConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
-        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold(Strategy.NO_CHANGE))
+                .thenReturn(35);
         this.identityScoreCalculator =
                 new IdentityScoreCalculator(mockFraudCheckConfigurationService);
 
         int identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, true);
+                        fraudCheckResult, true, Strategy.NO_CHANGE);
         identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterPEPCheck(identityScore, false);
         assertEquals(1, identityScore);
@@ -90,13 +93,13 @@ class IdentityScoreCalculatorTest {
         fraudCheckResult.setTransactionId("123456789");
 
         when(mockFraudCheckConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
-        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+
         this.identityScoreCalculator =
                 new IdentityScoreCalculator(mockFraudCheckConfigurationService);
 
         int identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, false);
+                        fraudCheckResult, false, Strategy.NO_CHANGE);
         identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterPEPCheck(identityScore, false);
         assertEquals(0, identityScore);
@@ -111,13 +114,13 @@ class IdentityScoreCalculatorTest {
         fraudCheckResult.setTransactionId("123456789");
 
         when(mockFraudCheckConfigurationService.getZeroScoreUcodes()).thenReturn(List.of("U001"));
-        when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
+
         this.identityScoreCalculator =
                 new IdentityScoreCalculator(mockFraudCheckConfigurationService);
 
         int identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterFraudCheck(
-                        fraudCheckResult, false);
+                        fraudCheckResult, false, Strategy.NO_CHANGE);
         identityScore =
                 identityScoreCalculator.calculateIdentityScoreAfterPEPCheck(identityScore, true);
         assertEquals(0, identityScore);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.cri.fraud.api.domain.check.FraudCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.domain.check.PepCheckResult;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyFraudGateway;
 import uk.gov.di.ipv.cri.fraud.api.gateway.ThirdPartyPepGateway;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.util.TestDataCreator;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
@@ -120,7 +121,8 @@ class IdentityVerificationServiceTest {
             verifyIdentityShouldReturnResultWhenValidInputProvidedDecisionScoreLessThanThresholdCrosscoreV2()
                     throws IOException, SqsException, OAuthErrorResponseException {
 
-        when(mockTokenRequestService.requestToken(false)).thenReturn("testTokenValue");
+        when(mockTokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE))
+                .thenReturn("testTokenValue");
 
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -137,7 +139,10 @@ class IdentityVerificationServiceTest {
 
         when(mockFraudCheckConfigurationService.getNoFileFoundThreshold()).thenReturn(35);
 
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(sessionItem.getClientId()).thenReturn("test_client_id");
+
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
@@ -162,9 +167,12 @@ class IdentityVerificationServiceTest {
                 result.getActivityFrom());
 
         verify(personIdentityValidator).validate(testPersonIdentity);
-        verify(mockThirdPartyFraudGateway).performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyFraudGateway)
+                .performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockThirdPartyPepGateway, never())
-                .performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+                .performPepCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
     }
 
@@ -172,7 +180,8 @@ class IdentityVerificationServiceTest {
     void verifyIdentityShouldReturnResultWhenValidInputProvidedCrosscoreV2()
             throws IOException, SqsException, OAuthErrorResponseException {
 
-        when(mockTokenRequestService.requestToken(false)).thenReturn("testTokenValue");
+        when(mockTokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE))
+                .thenReturn("testTokenValue");
 
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -194,12 +203,15 @@ class IdentityVerificationServiceTest {
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
 
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(sessionItem.getClientId()).thenReturn("test_client_id");
+
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
-
-        when(mockThirdPartyPepGateway.performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(mockThirdPartyPepGateway.performPepCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testPEPCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyPEPCodes))
                 .thenReturn(mappedPEPCodes);
@@ -230,9 +242,13 @@ class IdentityVerificationServiceTest {
                 result.getActivityFrom());
 
         verify(personIdentityValidator).validate(testPersonIdentity);
-        verify(mockThirdPartyFraudGateway).performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyFraudGateway)
+                .performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
-        verify(mockThirdPartyPepGateway).performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyPepGateway)
+                .performPepCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyPEPCodes);
     }
 
@@ -240,12 +256,15 @@ class IdentityVerificationServiceTest {
     void verifyIdentityShouldReturnErrorWhenThirdPartyCallFailsCrosscoreV2()
             throws IOException, SqsException, OAuthErrorResponseException {
 
-        when(mockTokenRequestService.requestToken(false)).thenReturn("testTokenValue");
+        when(mockTokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE))
+                .thenReturn("testTokenValue");
 
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(sessionItem.getClientId()).thenReturn("test_client_id");
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(null);
 
         IdentityVerificationResult result =
@@ -281,7 +300,9 @@ class IdentityVerificationServiceTest {
             boolean zeroScoreUCodePresent)
             throws IOException, SqsException, OAuthErrorResponseException {
 
-        when(mockTokenRequestService.requestToken(false)).thenReturn("testTokenValue");
+        when(mockTokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE))
+                .thenReturn("testTokenValue");
+        when(sessionItem.getClientId()).thenReturn("testClientId");
 
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -312,12 +333,14 @@ class IdentityVerificationServiceTest {
 
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testFraudCheckResult);
 
         // Pep performed scenarios - (score above threshold and no zeroScoreUCode found)
         if ((expectedDecisionScore > noFileFoundThreshold) && !zeroScoreUCodePresent) {
-            when(mockThirdPartyPepGateway.performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+            when(mockThirdPartyPepGateway.performPepCheck(
+                            testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                     .thenReturn(testPEPCheckResult);
             when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyPEPCodes))
                     .thenReturn(mappedPEPCodes);
@@ -329,7 +352,9 @@ class IdentityVerificationServiceTest {
 
         // Performed always for step 1 fraud check
         verify(personIdentityValidator).validate(testPersonIdentity);
-        verify(mockThirdPartyFraudGateway).performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyFraudGateway)
+                .performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
 
         assertNotNull(result);
@@ -340,7 +365,9 @@ class IdentityVerificationServiceTest {
 
         if ((expectedDecisionScore > noFileFoundThreshold) && !zeroScoreUCodePresent) {
             // Performed for step 2 pep check after fraud has succeeded
-            verify(mockThirdPartyPepGateway).performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+            verify(mockThirdPartyPepGateway)
+                    .performPepCheck(
+                            testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
             verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyPEPCodes);
 
             InOrder inOrder = inOrder(mockEventProbe);
@@ -394,8 +421,11 @@ class IdentityVerificationServiceTest {
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
 
+        when(sessionItem.getClientId()).thenReturn("test_client_id");
+
         // No VC in this scenario
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenThrow(new OAuthErrorResponseException(-1, ErrorResponse.FINAL_ERROR));
 
         IdentityVerificationResult result =
@@ -425,8 +455,11 @@ class IdentityVerificationServiceTest {
         when(personIdentityValidator.validate(testPersonIdentity))
                 .thenReturn(ValidationResult.createValidResult());
 
+        when(sessionItem.getClientId()).thenReturn("testClientId");
+
         // No VC in this scenario
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testFraudCheckResult);
 
         IdentityVerificationResult result =
@@ -458,8 +491,10 @@ class IdentityVerificationServiceTest {
         final int expectedIdentityFraudScore =
                 1; // Fraud Pass with Pep attempted but either network fail, sleep thread
         // interrupted or Error Response
+        when(sessionItem.getClientId()).thenReturn("testClientId");
 
-        when(mockTokenRequestService.requestToken(false)).thenReturn(TEST_ACCESS_TOKEN);
+        when(mockTokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE))
+                .thenReturn(TEST_ACCESS_TOKEN);
 
         PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
@@ -484,7 +519,8 @@ class IdentityVerificationServiceTest {
         when(mockFraudCheckConfigurationService.getNoFileFoundThreshold())
                 .thenReturn(noFileFoundThreshold);
 
-        when(mockThirdPartyFraudGateway.performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+        when(mockThirdPartyFraudGateway.performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                 .thenReturn(testFraudCheckResult);
         when(mockContraindicationMapper.mapThirdPartyFraudCodes(thirdPartyFraudCodes))
                 .thenReturn(mappedFraudCodes);
@@ -492,10 +528,12 @@ class IdentityVerificationServiceTest {
         when(mockActivityHistoryScoreCalculator.calculateActivityHistoryScore(366)).thenReturn(1);
 
         if (errorType.equals("OAuthErrorResponseException")) {
-            when(mockThirdPartyPepGateway.performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+            when(mockThirdPartyPepGateway.performPepCheck(
+                            testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                     .thenThrow(OAuthErrorResponseException.class);
         } else {
-            when(mockThirdPartyPepGateway.performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN))
+            when(mockThirdPartyPepGateway.performPepCheck(
+                            testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE))
                     .thenReturn(testPEPCheckResult);
         }
 
@@ -505,7 +543,9 @@ class IdentityVerificationServiceTest {
 
         // Performed always for step 1 fraud check
         verify(personIdentityValidator).validate(testPersonIdentity);
-        verify(mockThirdPartyFraudGateway).performFraudCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyFraudGateway)
+                .performFraudCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
         verify(mockContraindicationMapper).mapThirdPartyFraudCodes(thirdPartyFraudCodes);
 
         assertNotNull(result);
@@ -521,7 +561,9 @@ class IdentityVerificationServiceTest {
         // Fraud ucodes
         assertEquals(mappedFraudCodes[0], result.getContraIndicators().get(0));
         // Performed for step 2 pep check after fraud has succeeded
-        verify(mockThirdPartyPepGateway).performPepCheck(testPersonIdentity, TEST_ACCESS_TOKEN);
+        verify(mockThirdPartyPepGateway)
+                .performPepCheck(
+                        testPersonIdentity, TEST_ACCESS_TOKEN, TestStrategyClientId.NO_CHANGE);
 
         // Checks for DecisionScore > 35 and Pep Fail
         InOrder inOrder = inOrder(mockEventProbe);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.TokenResponse;
 import uk.gov.di.ipv.cri.fraud.api.persistence.item.TokenItem;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
@@ -144,7 +145,7 @@ class TokenRequestServiceTest {
                         eq("Token")))
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
 
-        String tokenValue = tokenRequestService.requestToken(false);
+        String tokenValue = tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
 
         // (POST) Token
         InOrder inOrderMockHttpRetryerSequence = inOrder(mockHttpRetryer);
@@ -194,7 +195,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -243,7 +246,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -297,7 +302,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -347,7 +354,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -406,14 +415,16 @@ class TokenRequestServiceTest {
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
         // Token put capture
         doNothing().when(mockTokenTable).putItem(dynamoPutItemTokenItemCaptor.capture());
-        String tokenResponseOne = tokenRequestService.requestToken(false);
+        String tokenResponseOne =
+                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
         assertEquals(TEST_TOKEN_VALID_VALUE, tokenResponseOne);
 
         // Request two
         TokenItem testTokenFromDynamo = dynamoPutItemTokenItemCaptor.getValue();
         // Captured token get
         when(mockTokenTable.getItem(TOKEN_ITEM_KEY)).thenReturn(testTokenFromDynamo);
-        String tokenResponseTwo = tokenRequestService.requestToken(false);
+        String tokenResponseTwo =
+                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
 
         assertEquals(tokenResponseOne, tokenResponseTwo);
 
@@ -470,7 +481,8 @@ class TokenRequestServiceTest {
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
         // Token put capture
         doNothing().when(mockTokenTable).putItem(dynamoPutItemTokenItemCaptor.capture());
-        String tokenResponseOne = tokenRequestService.requestToken(false);
+        String tokenResponseOne =
+                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
         assertEquals(TEST_TOKEN_VALID_VALUE, tokenResponseOne);
 
         // Request two
@@ -481,7 +493,8 @@ class TokenRequestServiceTest {
 
         // Captured token get
         when(mockTokenTable.getItem(TOKEN_ITEM_KEY)).thenReturn(testTokenFromDynamo);
-        String tokenResponseTwo = tokenRequestService.requestToken(false);
+        String tokenResponseTwo =
+                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
 
         assertEquals(tokenResponseOne, tokenResponseTwo);
 
@@ -551,7 +564,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token
@@ -615,7 +630,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token
@@ -678,7 +695,9 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () -> tokenRequestService.requestToken(true),
+                        () ->
+                                tokenRequestService.requestToken(
+                                        true, TestStrategyClientId.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
@@ -20,12 +20,12 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
-import uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.TestStrategyClientId;
 import uk.gov.di.ipv.cri.fraud.api.gateway.dto.response.TokenResponse;
 import uk.gov.di.ipv.cri.fraud.api.persistence.item.TokenItem;
 import uk.gov.di.ipv.cri.fraud.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.fraud.library.exception.OAuthErrorResponseException;
 import uk.gov.di.ipv.cri.fraud.library.service.HttpRetryer;
+import uk.gov.di.ipv.cri.fraud.library.strategy.Strategy;
 import uk.gov.di.ipv.cri.fraud.library.util.HTTPReply;
 
 import java.io.IOException;
@@ -145,7 +145,7 @@ class TokenRequestServiceTest {
                         eq("Token")))
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
 
-        String tokenValue = tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
+        String tokenValue = tokenRequestService.requestToken(false, Strategy.NO_CHANGE);
 
         // (POST) Token
         InOrder inOrderMockHttpRetryerSequence = inOrder(mockHttpRetryer);
@@ -195,9 +195,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -246,9 +244,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -302,9 +298,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -354,9 +348,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (Post) Token
@@ -415,16 +407,14 @@ class TokenRequestServiceTest {
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
         // Token put capture
         doNothing().when(mockTokenTable).putItem(dynamoPutItemTokenItemCaptor.capture());
-        String tokenResponseOne =
-                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
+        String tokenResponseOne = tokenRequestService.requestToken(false, Strategy.NO_CHANGE);
         assertEquals(TEST_TOKEN_VALID_VALUE, tokenResponseOne);
 
         // Request two
         TokenItem testTokenFromDynamo = dynamoPutItemTokenItemCaptor.getValue();
         // Captured token get
         when(mockTokenTable.getItem(TOKEN_ITEM_KEY)).thenReturn(testTokenFromDynamo);
-        String tokenResponseTwo =
-                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
+        String tokenResponseTwo = tokenRequestService.requestToken(false, Strategy.NO_CHANGE);
 
         assertEquals(tokenResponseOne, tokenResponseTwo);
 
@@ -481,8 +471,7 @@ class TokenRequestServiceTest {
                 .thenReturn(new HTTPReply(200, null, testTokenResponseString));
         // Token put capture
         doNothing().when(mockTokenTable).putItem(dynamoPutItemTokenItemCaptor.capture());
-        String tokenResponseOne =
-                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
+        String tokenResponseOne = tokenRequestService.requestToken(false, Strategy.NO_CHANGE);
         assertEquals(TEST_TOKEN_VALID_VALUE, tokenResponseOne);
 
         // Request two
@@ -493,8 +482,7 @@ class TokenRequestServiceTest {
 
         // Captured token get
         when(mockTokenTable.getItem(TOKEN_ITEM_KEY)).thenReturn(testTokenFromDynamo);
-        String tokenResponseTwo =
-                tokenRequestService.requestToken(false, TestStrategyClientId.NO_CHANGE);
+        String tokenResponseTwo = tokenRequestService.requestToken(false, Strategy.NO_CHANGE);
 
         assertEquals(tokenResponseOne, tokenResponseTwo);
 
@@ -564,9 +552,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token
@@ -630,9 +616,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token
@@ -695,9 +679,7 @@ class TokenRequestServiceTest {
         OAuthErrorResponseException thrownException =
                 assertThrows(
                         OAuthErrorResponseException.class,
-                        () ->
-                                tokenRequestService.requestToken(
-                                        true, TestStrategyClientId.NO_CHANGE),
+                        () -> tokenRequestService.requestToken(true, Strategy.NO_CHANGE),
                         "Expected OAuthErrorResponseException");
 
         // (POST) Token

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/error/ErrorResponse.java
@@ -40,6 +40,9 @@ public enum ErrorResponse {
     TOKEN_ENDPOINT_RETURNED_JWT_WITH_UNEXPECTED_VALUES_IN_RESPONSE(
             4005, "token endpoint returned unexpected values in JWT"),
 
+    TEST_DATA_STRATEGY_COULD_NOT_MAP_CLIENTID_TO_THIRD_PARTY_ROUTE(
+            4006, "could not map EndpointUri from TestDataStrategy logic"),
+
     FINAL_ERROR(-1, "Final Error");
 
     private final int code;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/service/ParameterStoreService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/service/ParameterStoreService.java
@@ -63,7 +63,7 @@ public class ParameterStoreService {
                 path,
                 parametersPath);
 
-        return ssmProvider.getMultiple(parametersPath);
+        return ssmProvider.recursive().getMultiple(parametersPath);
     }
 
     // Encrypted

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/strategy/Strategy.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/strategy/Strategy.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.cri.fraud.library.strategy;
+
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public enum Strategy {
+    STUB,
+    UAT,
+    LIVE,
+    NO_CHANGE;
+
+    public static Strategy fromClientIdString(String clientIdString) {
+        return switch (clientIdString) {
+            case "ipv-core-stub" -> STUB; // Legacy core-stub-id
+            case "ipv-core-stub-aws-build" -> STUB;
+            case "ipv-core-stub-aws-prod" -> STUB;
+            case "ipv-core-stub-aws-build_3rdparty" -> UAT;
+            case "ipv-core-stub-aws-prod_3rdparty" -> UAT;
+            case "ipv-core-stub-pre-prod-aws-build" -> LIVE;
+            case "ipv-core" -> LIVE;
+            default -> NO_CHANGE;
+        };
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/fraud/library/service/ParameterStoreServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/fraud/library/service/ParameterStoreServiceTest.java
@@ -90,12 +90,14 @@ class ParameterStoreServiceTest {
         String testPath = "TESTPATH/SUBPATH";
         String fullPath = String.format("/%s/%s", prefixToTest.getPrefixValue(), testPath);
 
+        when(mockSSMProvider.recursive()).thenReturn(mockSSMProvider);
         when(mockSSMProvider.getMultiple(fullPath)).thenReturn(testParameterMap);
 
         assertEquals(
                 testParameterMap,
                 parameterStoreService.getAllParametersFromPath(prefixToTest, testPath));
 
+        verify(mockSSMProvider).recursive();
         verify(mockSSMProvider).getMultiple(fullPath);
     }
 


### PR DESCRIPTION
### What changed
 - Updated configurationService to have functionality that can pull in Parameters with multiple values in the form of a JSON block. (This means one parameter can have a value for Stub, Uat and Live service)
  - Updated IdentityVerification service so that the value selected for parameters with multiple values is conditional on the clientId passed to the CRI from IpvCore/stub.
   - Created an enum for mapping the clientId to a value for routing purposes.
  - Updated tests to reflect above changes

- [LIME-967](https://govukverify.atlassian.net/browse/LIME-967)

[LIME-967]: https://govukverify.atlassian.net/browse/LIME-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ