### PR TITLE
LIME-967 - Updating TokenSaves to save a token based on TestStrategy

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
@@ -109,7 +109,7 @@ public class TokenRequestService {
             throws OAuthErrorResponseException {
         LOGGER.info("Checking Table {} for existing cached token", tokenTableName);
 
-        TokenItem tokenItem = getTokenItemFromTable();
+        TokenItem tokenItem = getTokenItemFromTable(strategy);
 
         boolean existingCachedToken = tokenItem != null;
         boolean tokenTtlHasExpired =
@@ -136,7 +136,7 @@ public class TokenRequestService {
 
                 tokenItem = new TokenItem(newTokenResponse.getAccessToken());
 
-                saveTokenItem(tokenItem);
+                saveTokenItem(tokenItem, strategy);
             } catch (Exception exception) {
                 LOGGER.error(
                         "Failed to generate new token. Continuing to use existing token ",
@@ -311,13 +311,14 @@ public class TokenRequestService {
         }
     }
 
-    private TokenItem getTokenItemFromTable() {
-        return dataStore.getItem(TOKEN_ITEM_ID);
+    private TokenItem getTokenItemFromTable(Strategy strategy) {
+        return dataStore.getItem(strategy.name() + TOKEN_ITEM_ID);
     }
 
-    private void saveTokenItem(TokenItem tokenItem) {
-        // id=TOKEN_ITEM_ID as same TokenItem is always used
-        tokenItem.setId(TOKEN_ITEM_ID);
+    private void saveTokenItem(TokenItem tokenItem, Strategy strategy) {
+        // id=<TestStrategyRoute>TOKEN_ITEM_ID as same TokenItem used is dependent on 3rd party
+        // route
+        tokenItem.setId(strategy.name() + TOKEN_ITEM_ID);
 
         long ttlSeconds = Instant.now().plusSeconds(TOKEN_ITEM_TTL_SECS).getEpochSecond();
 

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java
@@ -98,7 +98,8 @@ class TokenRequestServiceTest {
     private TokenRequestService tokenRequestService;
 
     @Mock DynamoDbTable<TokenItem> mockTokenTable; // To mock the internals of Datastore
-    private final Key TOKEN_ITEM_KEY = Key.builder().partitionValue(TOKEN_ITEM_ID).build();
+    private final Key TOKEN_ITEM_KEY =
+            Key.builder().partitionValue(Strategy.NO_CHANGE.name() + TOKEN_ITEM_ID).build();
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
### What changed
Token request service now saves a token in dynamo based on the test strategy routing. Making it possible to have 1 token generated for and used by our 3rd party stubs and another for UAT/LIVE.

### Why
This change was made as tokens are cached and re-used for up to 30 mins for third party requests. The logic in this PR negates the possibility of a token being generated by our stub, stored in dynamo, and then re-used in a later request intended for our 3rd parties UAT environment.