### PR TITLE
LIME-1070 Log ClientReferenceId/CorrelationId of all api requests

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
@@ -135,7 +135,10 @@ public class ThirdPartyFraudGateway {
         Instant startCheck = clock.instant();
 
         final HTTPReply httpReply;
-        LOGGER.info("Submitting {} request", REQUEST_NAME);
+        LOGGER.info(
+                "Submitting {} request... ClientReferenceId {}",
+                REQUEST_NAME,
+                apiRequest.getHeader().getClientReferenceId());
         try {
             httpReply =
                     httpRetryer.sendHTTPRequestRetryIfAllowed(

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
@@ -134,7 +134,10 @@ public class ThirdPartyPepGateway {
         Instant startCheck = clock.instant();
 
         final HTTPReply httpReply;
-        LOGGER.info("Submitting {} request...", REQUEST_NAME);
+        LOGGER.info(
+                "Submitting {} request... ClientReferenceId {}",
+                REQUEST_NAME,
+                apiRequest.getHeader().getClientReferenceId());
         try {
             httpReply =
                     httpRetryer.sendHTTPRequestRetryIfAllowed(

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestService.java
@@ -173,7 +173,7 @@ public class TokenRequestService {
         URI requestURI = selectRequestURI(strategy);
 
         final String correlationId = UUID.randomUUID().toString();
-        LOGGER.info("{} Correlation Id {}", REQUEST_NAME, correlationId);
+        LOGGER.info("{} CorrelationId {}", REQUEST_NAME, correlationId);
 
         // Token Request is posted as if via a form
         final HttpPost request = new HttpPost();

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayComponentTest.java
@@ -31,6 +31,7 @@ import uk.gov.di.ipv.cri.fraud.library.util.HTTPReply;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,7 +78,11 @@ class ThirdPartyFraudGatewayComponentTest {
     @Test
     void testCrosscoreV2PepsResponseBodyCanBeDeserialized()
             throws IOException, OAuthErrorResponseException {
+        final uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header testApiHeader =
+                new uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header();
+        testApiHeader.setClientReferenceId(UUID.randomUUID().toString());
         final PEPRequest testApiRequest = new PEPRequest();
+        testApiRequest.setHeader(testApiHeader);
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGatewayTest.java
@@ -35,6 +35,7 @@ import uk.gov.di.ipv.cri.fraud.library.util.HTTPReply;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,7 +90,8 @@ class ThirdPartyFraudGatewayTest {
     void shouldInvokeExperianCrosscoreV2ApiForClientId(Strategy strategy)
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+
+        IdentityVerificationRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -172,7 +174,8 @@ class ThirdPartyFraudGatewayTest {
     void shouldReturnOAuthErrorResponseExceptionIfThirdPartyApiReturnsInvalidCrosscoreV2Response()
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+
+        IdentityVerificationRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -253,7 +256,8 @@ class ThirdPartyFraudGatewayTest {
     void thirdPartyApiReturnsErrorOnUnexpectedHTTPStatusCrosscoreV2Response(int errorStatus)
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+
+        IdentityVerificationRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -310,6 +314,16 @@ class ThirdPartyFraudGatewayTest {
         assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
         assertHeaders(httpRequestCaptor);
+    }
+
+    private IdentityVerificationRequest createMockAPIRequest() {
+        final uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header testApiHeader =
+                new uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header();
+        testApiHeader.setClientReferenceId(UUID.randomUUID().toString());
+        final IdentityVerificationRequest testApiRequest = new IdentityVerificationRequest();
+        testApiRequest.setHeader(testApiHeader);
+
+        return testApiRequest;
     }
 
     private void assertHeaders(ArgumentCaptor<HttpEntityEnclosingRequestBase> httpRequestCaptor) {

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGatewayTest.java
@@ -35,6 +35,7 @@ import uk.gov.di.ipv.cri.fraud.library.util.HTTPReply;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,7 +99,8 @@ class ThirdPartyPepGatewayTest {
     void shouldInvokeCrosscoreV2PepApi(Strategy strategy)
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedPepApiRequest";
-        final PEPRequest testApiRequest = new PEPRequest();
+
+        final PEPRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -179,7 +181,8 @@ class ThirdPartyPepGatewayTest {
     void shouldReturnOAuthErrorResponseExceptionIfThirdPartyApiReturnsInvalidCrosscoreV2Response()
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final PEPRequest testApiRequest = new PEPRequest();
+
+        final PEPRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -260,7 +263,8 @@ class ThirdPartyPepGatewayTest {
     void thirdPartyApiReturnsErrorOnHTTP300CrosscoreV2Response(int errorStatus)
             throws IOException, OAuthErrorResponseException {
         final String testRequestBody = "serialisedCrossCoreApiRequest";
-        final PEPRequest testApiRequest = new PEPRequest();
+
+        final PEPRequest testApiRequest = createMockAPIRequest();
 
         PersonIdentity personIdentity =
                 TestDataCreator.createTestPersonIdentity(AddressType.CURRENT);
@@ -318,6 +322,16 @@ class ThirdPartyPepGatewayTest {
         assertEquals(EXPECTED_ERROR, actualPepCheckResult.getErrorMessage());
         assertEquals(HttpPost.class, httpRequestCaptor.getValue().getClass());
         assertHeaders(httpRequestCaptor, true);
+    }
+
+    private PEPRequest createMockAPIRequest() {
+        final uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header testApiHeader =
+                new uk.gov.di.ipv.cri.fraud.api.gateway.dto.request.Header();
+        testApiHeader.setClientReferenceId(UUID.randomUUID().toString());
+        final PEPRequest testApiRequest = new PEPRequest();
+        testApiRequest.setHeader(testApiHeader);
+
+        return testApiRequest;
     }
 
     private void assertHeaders(


### PR DESCRIPTION
## Proposed changes

### What changed

Added logging of ClientReferenceId to API requests
Changed logging of Correlation Id in token request to CorrelationId

### Why did it change

To enable tracing errors to specific requests CRI side and remotely with the third party.

### Issue tracking

- [LIME-1070](https://govukverify.atlassian.net/browse/LIME-1070)

[LIME-1070]: https://govukverify.atlassian.net/browse/LIME-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ