### PR TITLE
LIME-1069 - Added language Toggle Test

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -58,6 +58,9 @@ public class FraudPageObject extends UniversalSteps {
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/div/form/button")
     public WebElement checkYourDetailsContinue;
 
+    @FindBy(xpath = "/html/body/div[2]/main/div/div/form/button")
+    public WebElement checkYourDetailsContinueWales;
+
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/details/summary/span")
     public WebElement viewResponse;
 
@@ -150,6 +153,12 @@ public class FraudPageObject extends UniversalSteps {
 
     @FindBy(id = "SecondaryUKAddress.validUntilYear")
     public WebElement secondAddresssvalidToYearField;
+
+    @FindBy(xpath = "/html/body/div[2]/nav/ul/li[2]/a")
+    public WebElement languageToggle;
+
+    @FindBy(xpath = "/html/body/div[2]/nav/ul/li[1]/a")
+    public WebElement languageToggleWales;
 
     public FraudPageObject() {
         this.configurationService = new ConfigurationService(System.getenv("ENVIRONMENT"));

--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/step_definitions/FraudStepDefs.java
@@ -2,6 +2,7 @@ package gov.di_ipv_fraud.step_definitions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.di_ipv_fraud.pages.FraudPageObject;
+import gov.di_ipv_fraud.utilities.BrowserUtils;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -38,6 +39,13 @@ public class FraudStepDefs extends FraudPageObject {
     @And("^I navigate to the verifiable issuer to check for a (.*) response from thirdParty")
     public void navigateToVerifiableIssuer(String validOrInvalid) {
         navigateToResponse(validOrInvalid);
+    }
+
+    @And("^User clicks Parhau")
+    public void userClicksParhau() {
+        checkYourDetailsContinueWales.click();
+        BrowserUtils.waitForVisibility(viewResponse, 5);
+        viewResponse.click();
     }
 
     @Then("^I navigate to (.*) and assert I have been directed correctly$")
@@ -196,5 +204,15 @@ public class FraudStepDefs extends FraudPageObject {
     @And("^JSON payload should contain JTI field$")
     public void jsonPayloadShouldContainJtiField() throws IOException {
         assertJtiIsPresentAndNotNull();
+    }
+
+    @Given("User clicks on language toggle and switches to Welsh")
+    public void userClickOnLanguageToggle() {
+        languageToggle.click();
+    }
+
+    @Given("User clicks language toggle and switches to English")
+    public void userClickOnLanguageToggleWales() {
+        languageToggleWales.click();
     }
 }

--- a/acceptance-tests/src/test/resources/features/english/FraudCRI.feature
+++ b/acceptance-tests/src/test/resources/features/english/FraudCRI.feature
@@ -344,3 +344,13 @@ Feature: Fraud CRI
     Examples:
       | name                    | dob              | ci   | score  |
       | ALBERT NO_FILE_35       | 05/10/1943       |      | 1      |
+
+  @build-fraud @stub
+  Scenario: Language Toggle Validation
+    Given I navigate to the IPV Core Stub
+    And I click the Fraud CRI for the testEnvironment
+    Then I search for user number 12 in the ThirdParty table
+    Then User clicks on language toggle and switches to Welsh
+    And User clicks Parhau
+    And JSON payload should contain JTI field
+    And The test is complete and I close the driver


### PR DESCRIPTION
### What changed

Added language toggle test

### Why did it change

To add coverage for a new shared component called [one login language toggle](https://www.npmjs.com/package/@govuk-one-login/one-login-language-toggle) 

### Issue tracking

- [LIME-1069](https://govukverify.atlassian.net/browse/LIME-1069)

[LIME-1069]: https://govukverify.atlassian.net/browse/LIME-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ