### PR TITLE
LIME-1075 Reduce sensitivity of ac tests to test runner cpu load

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java
@@ -216,10 +216,10 @@ public class FraudPageObject extends UniversalSteps {
         assertURLContains("callback");
 
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
-            BrowserUtils.waitForVisibility(errorResponse, 5);
+            BrowserUtils.waitForVisibility(errorResponse, 60);
             errorResponse.click();
         } else {
-            BrowserUtils.waitForVisibility(viewResponse, 5);
+            BrowserUtils.waitForVisibility(viewResponse, 60);
             viewResponse.click();
         }
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Reduce sensitivity of ac tests to test runner cpu load

### Why did it change

Timing inside the ac test is not tolerant of any delays due to load on the system the runners are executing, introducing intermittent test failures.

### Issue tracking

- [LIME-1075](https://govukverify.atlassian.net/browse/LIME-1075)


[LIME-1075]: https://govukverify.atlassian.net/browse/LIME-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ