### PR TITLE
LIME-1115 Add support for setting txma-audit-encoded in audit events

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fix.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "1.5.3",
+		cri_common_lib_version             : "1.6.1",
 
 		// CRI_LIB aws
 		aws_sdk_version                    : "2.20.162",

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
 
-		cri_common_lib_version             : "1.5.6",
+		cri_common_lib_version             : "1.6.1",
 
 		// CRI_LIB aws
 		aws_sdk_version                    : "2.20.162",

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -12,6 +12,7 @@ paths:
             type: string
             format: uuid
           required: true
+        - $ref: '#/components/parameters/AuditHeader'
       requestBody:
         content:
           application/json: {}
@@ -51,6 +52,8 @@ paths:
 
   /session:
     post:
+      parameters:
+        - $ref: '#/components/parameters/AuditHeader'
       requestBody:
         content:
           application/json:
@@ -97,6 +100,7 @@ paths:
             type: string
             format: uuid
           required: true
+        - $ref: '#/components/parameters/AuditHeader'
       responses:
         "200":
           description: "200 response"
@@ -125,6 +129,14 @@ paths:
         passthroughBehavior: "when_no_match"
 
 components:
+  parameters:
+    AuditHeader:
+      name: txma-audit-encoded
+      in: header
+      description: An encoded header sent by the FE containing info about request origin
+      required: false
+      schema:
+        type: string
   schemas:
     Authorization:
       required:
@@ -170,6 +182,7 @@ components:
       properties:
         session_id:
           type: "string"
+
 
 x-amazon-apigateway-request-validators:
   Validate both:


### PR DESCRIPTION
## Proposed changes

### What changed

API side of enabling support for setting txma-audit-encoded in audit events

### Why did it change

To enable the feature.

### Issue tracking

- [LIME-1115](https://govukverify.atlassian.net/browse/LIME-1115)


[LIME-1115]: https://govukverify.atlassian.net/browse/LIME-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ