### PR TITLE
LIME-1166 Send decisionScore as Integer in VC_ISSUED audit event

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/IdentityVerificationResult.java
@@ -13,7 +13,7 @@ public class IdentityVerificationResult {
     private String activityFrom;
     private String transactionId;
     private String pepTransactionId;
-    private String decisionScore;
+    private Integer decisionScore;
     private List<String> thirdPartyFraudCodes = new ArrayList<>();
 
     // These checks have specific meanings and appear in the VC
@@ -76,11 +76,11 @@ public class IdentityVerificationResult {
         this.pepTransactionId = pepTransactionId;
     }
 
-    public String getDecisionScore() {
+    public Integer getDecisionScore() {
         return decisionScore;
     }
 
-    public void setDecisionScore(String decisionScore) {
+    public void setDecisionScore(Integer decisionScore) {
         this.decisionScore = decisionScore;
     }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/FraudCheckResult.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/check/FraudCheckResult.java
@@ -5,7 +5,7 @@ public class FraudCheckResult {
     private String[] thirdPartyFraudCodes;
     private String errorMessage;
     private String transactionId;
-    private String decisionScore;
+    private Integer decisionScore;
     private Integer oldestRecordDateInMonths;
 
     public FraudCheckResult() {
@@ -44,11 +44,11 @@ public class FraudCheckResult {
         this.transactionId = transactionId;
     }
 
-    public String getDecisionScore() {
+    public Integer getDecisionScore() {
         return decisionScore;
     }
 
-    public void setDecisionScore(String decisionScore) {
+    public void setDecisionScore(Integer decisionScore) {
         this.decisionScore = decisionScore;
     }
 

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapper.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapper.java
@@ -202,7 +202,7 @@ public class IdentityVerificationResponseMapper {
 
             fraudCheckResult.setThirdPartyFraudCodes(
                     fraudCodes.toArray(fraudCodes.toArray(String[]::new)));
-            fraudCheckResult.setDecisionScore(String.valueOf(decisionScore));
+            fraudCheckResult.setDecisionScore(decisionScore);
 
             eventProbe.counterMetric(THIRD_PARTY_FRAUD_RESPONSE_TYPE_INFO_VALIDATION_PASS);
         } else {

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationService.java
@@ -292,7 +292,7 @@ public class IdentityVerificationService {
         LOGGER.info("Activity history score {}", activityHistoryScore);
 
         // For deciding if a pepCheck should be done
-        int decisionScore = Integer.parseInt(fraudCheckResult.getDecisionScore());
+        Integer decisionScore = fraudCheckResult.getDecisionScore();
         identityVerificationResult.setDecisionScore(fraudCheckResult.getDecisionScore());
 
         LOGGER.info("IdentityCheckScore after Fraud {}", fraudIdentityCheckScore);

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/gateway/IdentityVerificationResponseMapperTest.java
@@ -73,7 +73,7 @@ class IdentityVerificationResponseMapperTest {
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals("90", fraudCheckResult.getDecisionScore());
+        assertEquals(90, fraudCheckResult.getDecisionScore());
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
     }
 
@@ -720,7 +720,7 @@ class IdentityVerificationResponseMapperTest {
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals("90", fraudCheckResult.getDecisionScore());
+        assertEquals(90, fraudCheckResult.getDecisionScore());
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
 
         assertEquals(
@@ -764,7 +764,7 @@ class IdentityVerificationResponseMapperTest {
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals("90", fraudCheckResult.getDecisionScore());
+        assertEquals(90, fraudCheckResult.getDecisionScore());
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
 
         assertEquals(
@@ -822,7 +822,7 @@ class IdentityVerificationResponseMapperTest {
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals("90", fraudCheckResult.getDecisionScore());
+        assertEquals(90, fraudCheckResult.getDecisionScore());
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
 
         assertEquals(
@@ -880,7 +880,7 @@ class IdentityVerificationResponseMapperTest {
         assertTrue(fraudCheckResult.isExecutedSuccessfully());
         assertNull(fraudCheckResult.getErrorMessage());
         assertEquals(1, fraudCheckResult.getThirdPartyFraudCodes().length);
-        assertEquals("90", fraudCheckResult.getDecisionScore());
+        assertEquals(90, fraudCheckResult.getDecisionScore());
         assertEquals(rule.getRuleId(), fraudCheckResult.getThirdPartyFraudCodes()[0]);
 
         assertEquals(

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandlerTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandlerTest.java
@@ -115,7 +115,7 @@ class FraudHandlerTest {
         testIdentityVerificationResult.setSuccess(true);
         testIdentityVerificationResult.setContraIndicators(List.of("A01"));
         testIdentityVerificationResult.setIdentityCheckScore(1);
-        testIdentityVerificationResult.setDecisionScore("90");
+        testIdentityVerificationResult.setDecisionScore(90);
         testIdentityVerificationResult.setChecksSucceeded(
                 List.of("check_one", "check_two", "check_three"));
         testIdentityVerificationResult.setChecksFailed(new ArrayList<>());
@@ -165,17 +165,15 @@ class FraudHandlerTest {
     }
 
     @Test
-    void handleResponseShouldReturnOkResponseWhenSessionAttemptGreaterThanOneAndResultFound()
-            throws IOException, SqsException {
+    void handleResponseShouldReturnOkResponseWhenSessionAttemptGreaterThanOneAndResultFound() {
         String testRequestBody = "request body";
-        PersonIdentity testPersonIdentity = TestDataCreator.createTestPersonIdentity();
 
         IdentityVerificationResult testIdentityVerificationResult =
                 new IdentityVerificationResult();
         testIdentityVerificationResult.setSuccess(true);
         testIdentityVerificationResult.setContraIndicators(List.of("A01"));
         testIdentityVerificationResult.setIdentityCheckScore(1);
-        testIdentityVerificationResult.setDecisionScore("90");
+        testIdentityVerificationResult.setDecisionScore(90);
         testIdentityVerificationResult.setChecksSucceeded(
                 List.of("check_one", "check_two", "check_three"));
         testIdentityVerificationResult.setChecksFailed(new ArrayList<>());
@@ -233,7 +231,7 @@ class FraudHandlerTest {
         testIdentityVerificationResult.setSuccess(true);
         testIdentityVerificationResult.setContraIndicators(List.of("A01"));
         testIdentityVerificationResult.setIdentityCheckScore(1);
-        testIdentityVerificationResult.setDecisionScore("90");
+        testIdentityVerificationResult.setDecisionScore(90);
         testIdentityVerificationResult.setChecksSucceeded(
                 List.of("check_one", "check_two", "check_three"));
         testIdentityVerificationResult.setChecksFailed(new ArrayList<>());

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityScoreCalculatorTest.java
@@ -21,7 +21,7 @@ class IdentityScoreCalculatorTest {
     @Test
     void testSuccessInFraudAndSuccessInPepIsScoreOfTwo() {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
-        fraudCheckResult.setDecisionScore("40");
+        fraudCheckResult.setDecisionScore(40);
         fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
         fraudCheckResult.setExecutedSuccessfully(true);
         fraudCheckResult.setTransactionId("123456789");
@@ -44,7 +44,7 @@ class IdentityScoreCalculatorTest {
     @Test
     void testSuccessInFraudAndSuccessInPepWithZeroScoreUcodeIsScoreOfZero() {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
-        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setDecisionScore(45);
         fraudCheckResult.setThirdPartyFraudCodes(new String[] {"U001"});
         fraudCheckResult.setExecutedSuccessfully(true);
         fraudCheckResult.setTransactionId("123456789");
@@ -65,7 +65,7 @@ class IdentityScoreCalculatorTest {
     @Test
     void testSuccessInFraudAndFailInPepIsScoreOfOne() {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
-        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setDecisionScore(45);
         fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
         fraudCheckResult.setExecutedSuccessfully(true);
         fraudCheckResult.setTransactionId("123456789");
@@ -87,7 +87,7 @@ class IdentityScoreCalculatorTest {
     @Test
     void testFailInFraudAndFailInPepIsScoreOfZero() {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
-        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setDecisionScore(45);
         fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
         fraudCheckResult.setExecutedSuccessfully(false);
         fraudCheckResult.setTransactionId("123456789");
@@ -108,7 +108,7 @@ class IdentityScoreCalculatorTest {
     @Test
     void testFailInFraudAndSuccessInPepIsScoreOfZero() {
         FraudCheckResult fraudCheckResult = new FraudCheckResult();
-        fraudCheckResult.setDecisionScore("45");
+        fraudCheckResult.setDecisionScore(45);
         fraudCheckResult.setThirdPartyFraudCodes(new String[] {});
         fraudCheckResult.setExecutedSuccessfully(false);
         fraudCheckResult.setTransactionId("123456789");

--- a/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/IdentityVerificationServiceTest.java
@@ -136,7 +136,7 @@ class IdentityVerificationServiceTest {
 
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
-        testFraudCheckResult.setDecisionScore("35");
+        testFraudCheckResult.setDecisionScore(35);
 
         String[] thirdPartyFraudCodes = new String[] {"sample-f-code"};
         String[] mappedFraudCodes = new String[] {"mapped-f-code"};
@@ -206,7 +206,7 @@ class IdentityVerificationServiceTest {
 
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
-        testFraudCheckResult.setDecisionScore("60");
+        testFraudCheckResult.setDecisionScore(60);
         testFraudCheckResult.setOldestRecordDateInMonths(366);
 
         PepCheckResult testPEPCheckResult = new PepCheckResult();
@@ -338,7 +338,7 @@ class IdentityVerificationServiceTest {
 
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
-        testFraudCheckResult.setDecisionScore(String.valueOf(expectedDecisionScore));
+        testFraudCheckResult.setDecisionScore(expectedDecisionScore);
         String[] thirdPartyFraudCodes = new String[] {"sample-f-code"};
         String[] mappedFraudCodes = new String[] {"mapped-f-code"};
         testFraudCheckResult.setThirdPartyFraudCodes(thirdPartyFraudCodes);
@@ -528,7 +528,7 @@ class IdentityVerificationServiceTest {
 
         FraudCheckResult testFraudCheckResult = new FraudCheckResult();
         testFraudCheckResult.setExecutedSuccessfully(true);
-        testFraudCheckResult.setDecisionScore(String.valueOf(expectedDecisionScore));
+        testFraudCheckResult.setDecisionScore(expectedDecisionScore);
         String[] thirdPartyFraudCodes = new String[] {"sample-f-code"};
         String[] mappedFraudCodes = new String[] {"mapped-f-code"};
         testFraudCheckResult.setThirdPartyFraudCodes(thirdPartyFraudCodes);
@@ -536,9 +536,8 @@ class IdentityVerificationServiceTest {
 
         PepCheckResult testPEPCheckResult = new PepCheckResult();
         testPEPCheckResult.setExecutedSuccessfully(
-                errorType.equals("PEPExecutedSuccessfullyFalse") ? false : true);
+                !errorType.equals("PEPExecutedSuccessfullyFalse"));
         String[] thirdPartyPEPCodes = new String[] {"sample-p-code"};
-        String[] mappedPEPCodes = new String[] {"mapped-p-code"};
         testPEPCheckResult.setThirdPartyFraudCodes(thirdPartyPEPCodes);
 
         when(personIdentityValidator.validate(testPersonIdentity))

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/domain/Evidence.java
@@ -26,7 +26,7 @@ public class Evidence {
     private List<String> ci;
 
     @JsonProperty("decisionScore")
-    private String decisionScore;
+    private Integer decisionScore;
 
     @JsonProperty("checkDetails")
     private List<Check> checkDetails;
@@ -66,11 +66,11 @@ public class Evidence {
         this.ci = ci;
     }
 
-    public String getDecisionScore() {
+    public Integer getDecisionScore() {
         return decisionScore;
     }
 
-    public void setDecisionScore(String decisionScore) {
+    public void setDecisionScore(Integer decisionScore) {
         this.decisionScore = decisionScore;
     }
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandlerTest.java
@@ -101,7 +101,7 @@ class IssueCredentialHandlerTest {
                         TestDataCreator.createTestPersonIdentity());
         SessionItem sessionItem = new SessionItem();
         FraudResultItem fraudResultItem =
-                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, 1, "90");
+                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, 1, 90);
 
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(any()))
@@ -157,7 +157,7 @@ class IssueCredentialHandlerTest {
 
         SessionItem sessionItem = new SessionItem();
         FraudResultItem fraudResultItem =
-                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, 1, "90");
+                new FraudResultItem(UUID.randomUUID(), List.of(""), 1, 1, 90);
 
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
         when(mockPersonIdentityService.getPersonIdentityDetailed(any()))

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/pact/IssueCredentialHandlerTest.java
@@ -247,14 +247,13 @@ class IssueCredentialHandlerTest {
                                 AccessToken.parse(
                                         "Bearer dummyAccessToken", AccessTokenType.BEARER))
                         .getSessionId();
-        String sessionId = sessionUUID.toString();
 
         FraudResultItem resultItem = new FraudResultItem();
         resultItem.setTransactionId("dummyTxn"); // Crosscore Id
         resultItem.setPepTransactionId("dummyTxnFailed");
         resultItem.setActivityHistoryScore(1);
         resultItem.setIdentityFraudScore(1);
-        resultItem.setDecisionScore("30");
+        resultItem.setDecisionScore(30);
         resultItem.setActivityFrom("2013-12-01");
         resultItem.setCheckDetails(
                 List.of(
@@ -276,14 +275,13 @@ class IssueCredentialHandlerTest {
                                 AccessToken.parse(
                                         "Bearer dummyAccessToken", AccessTokenType.BEARER))
                         .getSessionId();
-        String sessionId = sessionUUID.toString();
 
         FraudResultItem resultItem = new FraudResultItem();
         resultItem.setTransactionId("dummyTxn"); // Crosscore Id
         resultItem.setPepTransactionId("dummyTxn");
         resultItem.setActivityHistoryScore(1);
         resultItem.setIdentityFraudScore(2);
-        resultItem.setDecisionScore("30");
+        resultItem.setDecisionScore(30);
         resultItem.setActivityFrom("2013-12-01");
         resultItem.setContraIndicators(List.of());
         resultItem.setCheckDetails(
@@ -332,7 +330,6 @@ class IssueCredentialHandlerTest {
                                 AccessToken.parse(
                                         "Bearer dummyAccessToken", AccessTokenType.BEARER))
                         .getSessionId();
-        String sessionId = sessionUUID.toString();
 
         FraudResultItem resultItem = new FraudResultItem();
         resultItem.setContraIndicators(List.of("CI1"));
@@ -340,7 +337,7 @@ class IssueCredentialHandlerTest {
         resultItem.setPepTransactionId("dummyTxn");
         resultItem.setActivityHistoryScore(1);
         resultItem.setIdentityFraudScore(2);
-        resultItem.setDecisionScore("30");
+        resultItem.setDecisionScore(30);
         resultItem.setActivityFrom("2013-12-01");
         resultItem.setCheckDetails(
                 List.of(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/VerifiableCredentialServiceTest.java
@@ -118,7 +118,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
     private JsonNode setupTest(int addressCount, long maxExpiryTime)
             throws JOSEException, JsonProcessingException, ParseException {
         FraudResultItem fraudResultItem =
-                new FraudResultItem(UUID.randomUUID(), List.of("A01"), 1, 1, "90");
+                new FraudResultItem(UUID.randomUUID(), List.of("A01"), 1, 1, 90);
 
         PersonIdentityDetailed personIdentityDetailed =
                 FraudPersonIdentityDetailedMapper.generatePersonIdentityDetailed(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/fraud/library/persistence/item/FraudResultItem.java
@@ -18,7 +18,7 @@ public class FraudResultItem {
     private String activityFrom;
     private String transactionId;
     private String pepTransactionId;
-    private String decisionScore;
+    private Integer decisionScore;
 
     private List<String> checkDetails;
     private List<String> failedCheckDetails;
@@ -32,7 +32,7 @@ public class FraudResultItem {
             List<String> contraIndicators,
             Integer identityFraudScore,
             Integer activityHistoryScore,
-            String decisionScore) {
+            Integer decisionScore) {
         this.sessionId = sessionId;
         this.contraIndicators = contraIndicators;
         this.identityFraudScore = identityFraudScore;
@@ -81,11 +81,11 @@ public class FraudResultItem {
         this.pepTransactionId = pepTransactionId;
     }
 
-    public String getDecisionScore() {
+    public Integer getDecisionScore() {
         return decisionScore;
     }
 
-    public void setDecisionScore(String decisionScore) {
+    public void setDecisionScore(Integer decisionScore) {
         this.decisionScore = decisionScore;
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Send decisionScore as Integer in VC_ISSUED audit event
Keeps previous behaviour of decisionScore not being present in VC (not requested previously)

### Why did it change

decisionScore was being captured and sent as a String

### Issue tracking

- [LIME-1166](https://govukverify.atlassian.net/browse/LIME-1166)

[LIME-1166]: https://govukverify.atlassian.net/browse/LIME-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ