### PR TITLE
LIME-1166 Correct sonar-scan not running against main post merge

### DIFF
--- a/.github/workflows/post-merge-sonar-scan.yml
+++ b/.github/workflows/post-merge-sonar-scan.yml
@@ -1,0 +1,43 @@
+name: Post merge Sonar scan on main
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # deploy manually
+
+jobs:
+  sonar-scan-main:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: 'gradle'
+      - name: Build Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Unit Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew --parallel test report -x jacocoTestReport -x spotlessApply -x spotlessCheck
+      - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar -x test -x spotlessApply -x spotlessCheck


### PR DESCRIPTION
## Proposed changes

### What changed

Post merge of LIME-1166 the sonar scan of main did not happen

### Why did it change

Add dedicated post merge sonar action scan action - to avoid re-running the heavier pre-merge workflow post merge.

### Issue tracking

- [LIME-1166](https://govukverify.atlassian.net/browse/LIME-1166)

[LIME-1166]: https://govukverify.atlassian.net/browse/LIME-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ