### PR TITLE
LIME-1166 Remove dependency in sonar scan workflow

### DIFF
--- a/.github/workflows/post-merge-sonar-scan.yml
+++ b/.github/workflows/post-merge-sonar-scan.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   sonar-scan-main:
     runs-on: ubuntu-latest
-    needs:
-      - build
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Proposed changes

### What changed

Remove build dependency in sonar scan workflow

### Why did it change

Sonar scan workflow was based on existing workflow, which had a build step.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1166](https://govukverify.atlassian.net/browse/LIME-1166)

[LIME-1166]: https://govukverify.atlassian.net/browse/LIME-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ