### PR TITLE
LIME-1175 Increase authenticateplus timeout to 6 seconds

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyFraudGateway.java
@@ -60,9 +60,9 @@ public class ThirdPartyFraudGateway {
     private final HttpRetryer httpRetryer;
 
     // POOL_REQ + CONN_EST + HTTP_RESP = overall max timeout
-    private static final int POOL_REQUEST_TIMEOUT_MS = 5000;
-    private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 5000;
-    public static final int FRAUD_HTTP_RESPONSE_TIMEOUT_MS = 5000;
+    private static final int POOL_REQUEST_TIMEOUT_MS = 1000;
+    private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 3000;
+    public static final int FRAUD_HTTP_RESPONSE_TIMEOUT_MS = 6000;
     private final RequestConfig fraudCheckRequestConfig;
 
     private final StopWatch stopWatch;

--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/gateway/ThirdPartyPepGateway.java
@@ -59,8 +59,8 @@ public class ThirdPartyPepGateway {
     private final HttpRetryer httpRetryer;
 
     // POOL_REQ + CONN_EST + HTTP_RESP = overall max timeout
-    private static final int POOL_REQUEST_TIMEOUT_MS = 5000;
-    private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 5000;
+    private static final int POOL_REQUEST_TIMEOUT_MS = 1000;
+    private static final int CONNECTION_ESTABLISHMENT_TIMEOUT_MS = 3000;
     public static final int PEP_HTTP_RESPONSE_TIMEOUT_MS = 20000;
     private final RequestConfig pepCheckRequestConfig;
 


### PR DESCRIPTION
## Proposed changes

### What changed

Increase authenticate-plus timeout to 6 seconds

Correct pool timeouts being set to unreasonably high values

HTTP Connect establishment timeouts lowered to 3 seconds.

### Why did it change

To align with authenticate-plus api latency

Connection pool-time out was unreasonably high (5s), when combined with HTTP connection establishment and HTTP read timeouts would appear to indicate that 15 seconds total was available for authenticate-plus connections. Pool timeout lowered to 1 second as there should always be a connection available from the pool. 

HTTP Connect establishment timeouts lowered as part of a gradual reduction to a more reasonable value.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1175](https://govukverify.atlassian.net/browse/LIME-1175)

[LIME-1175]: https://govukverify.atlassian.net/browse/LIME-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ