### PR TITLE
LIME-843 Only allow one smoke test to run concurrently to avoid result publishing issues

### DIFF
--- a/.github/workflows/smoke-test-build.yml
+++ b/.github/workflows/smoke-test-build.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 5 * * 1-5"
   push:
 
+concurrency:
+  group: smoke-test-build
+  cancel-in-progress: false
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes

### What changed

Added a concurrency group to the smoke test

### Why did it change

To prevent multiple smoke tests running at the same time, then trying to publish the result using the same pages branch reference.

### Issue tracking

- [LIME-843](https://govukverify.atlassian.net/browse/LIME-843)


[LIME-843]: https://govukverify.atlassian.net/browse/LIME-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ