### PR TITLE
LIME-1114 SessionNotFoundExceptions added to handlers

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/IssueCredentialHandler.java
@@ -158,6 +158,11 @@ public class IssueCredentialHandler
             LOGGER.info("Validating authorization token...");
             var accessToken = validateInputHeaderBearerToken(input.getHeaders());
             var sessionItem = this.sessionService.getSessionByAccessToken(accessToken);
+
+            if (sessionItem == null || sessionItem.getSessionId() == null) {
+                throw new SessionNotFoundException("Session is not found");
+            }
+
             LOGGER.info("Extracted session from session store ID {}", sessionItem.getSessionId());
 
             LOGGER.info("Retrieving identity details and fraud results...");
@@ -192,7 +197,6 @@ public class IssueCredentialHandler
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatusCode.OK, signedJWT.serialize());
         } catch (SessionNotFoundException e) {
-
             String customOAuth2ErrorDescription = SESSION_NOT_FOUND.getMessage();
             LOGGER.error(customOAuth2ErrorDescription);
             eventProbe.counterMetric(Definitions.LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR);


### PR DESCRIPTION
LIME-1114 SessionNotFoundExceptions added to handlers

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
SessionNotFoundException added to both fraud check and issue credential handlers. Corresponding unit tests also created. 

### Why did it change

To ensure scenarios where a user has no session id are identified promptly and the correct error is returned. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)

PR for equivalent changes in passport CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/169)
PR for equivalent changes in dl CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-dl-api/pull/234)



[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ