### PR TITLE
[LIME-1114] added sessionID validation UUID check

### DIFF
--- a/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
+++ b/lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/handler/FraudHandler.java
@@ -51,6 +51,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
 
@@ -209,7 +210,7 @@ public class FraudHandler
             Map<String, String> headers = input.getHeaders();
             final String sessionId = headers.get("session_id");
 
-            if (sessionId == null) {
+            if (sessionId == null || sessionIdIsNotUUID(sessionId)) {
                 throw new SessionNotFoundException("Session ID not found");
             }
 
@@ -328,6 +329,13 @@ public class FraudHandler
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR));
         }
+    }
+
+    public boolean sessionIdIsNotUUID(String sessionId) {
+        Pattern uuidRegex =
+                Pattern.compile(
+                        "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+        return !uuidRegex.matcher(sessionId).matches();
     }
 
     private FraudResultItem createFraudResultItem(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes
Issue during testing where an empty value for the session_id header was returning Unexpected server error.
Update CheckPassportHandler.java to use UUID so it catches incorrect strings/special chars

### What changed

Added UUID check for sessionID in CheckPassportHandler.java
Added unit test for invalid sessionID in CheckPassportHandlerTest.java

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)
- [LIME-1289](https://govukverify.atlassian.net/browse/LIME-1289)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1289]: https://govukverify.atlassian.net/browse/LIME-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ