### PR TITLE
LIME-1280 Add feature flag to toggle the addition of address details in pep requests

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -226,22 +226,27 @@ Mappings:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "true"
+      IncludeAddressInPepReq: "false"
     build:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
+      IncludeAddressInPepReq: "false"
     staging:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
+      IncludeAddressInPepReq: "false"
     integration:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
+      IncludeAddressInPepReq: "true"
     production:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
+      IncludeAddressInPepReq: "true"
 
 Resources:
 
@@ -443,6 +448,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-identitycheck"
           ENVIRONMENT: !Ref Environment
           DEV_ENVIRONMENT_ONLY_ENHANCED_DEBUG: !FindInMap [ DevEnvironmentOnlyEnhancedDebugMappingEnvVar, Environment, !Ref Environment ]
+          ENV_VAR_FEATURE_FLAG_INCLUDE_ADDRESS_IN_PEP_REQ: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeAddressInPepReq ]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Add feature flag to toggle the addition of address details in pep requests

### Why did it change

To test if there is any positive or negative impact not setting values for a non-mandatory field, prior to permanent removal.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1280](https://govukverify.atlassian.net/browse/LIME-1280)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1280]: https://govukverify.atlassian.net/browse/LIME-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ