### PR TITLE
LIME-1169 Set log group retention in days to 30 for all log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -113,7 +117,8 @@
         "type": "Base64 High Entropy String",
         "filename": "acceptance-tests/src/test/resources/axe.min.js",
         "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 12
       }
     ],
     "infrastructure/lambda/public-api.yaml": [
@@ -121,63 +126,73 @@
         "type": "JSON Web Token",
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 34
       },
       {
         "type": "JSON Web Token",
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 95
       }
     ],
     "infrastructure/lambda/template.yaml": [
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
-        "is_verified": false
+        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
+        "is_verified": false,
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
-        "is_verified": false
+        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
+        "is_verified": false,
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
-        "is_verified": false
+        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
+        "is_verified": false,
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 138
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 174
       }
     ],
     "lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java": [
@@ -185,59 +200,68 @@
         "type": "Secret Keyword",
         "filename": "lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java",
         "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 19
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/fraudcheck/src/main/java/uk/gov/di/ipv/cri/fraud/api/service/CrosscoreV2Configuration.java",
         "hashed_secret": "9b8b876c2782fa992fab14095267bb8757b9fabc",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 21
       }
     ],
     "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java": [
       {
         "type": "Secret Keyword",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java",
-        "hashed_secret": "6d0b8d06b6893483f42260e85d2f96ef5ce6b36b",
-        "is_verified": false
+        "hashed_secret": "bf8d1f0a635e0b07327aa8dbda68bfe061021366",
+        "is_verified": false,
+        "line_number": 57
       },
       {
         "type": "Secret Keyword",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/FraudCheckConfigurationServiceTest.java",
-        "hashed_secret": "bf8d1f0a635e0b07327aa8dbda68bfe061021366",
-        "is_verified": false
+        "hashed_secret": "6d0b8d06b6893483f42260e85d2f96ef5ce6b36b",
+        "is_verified": false,
+        "line_number": 59
       }
     ],
     "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java": [
       {
-        "type": "Secret Keyword",
+        "type": "JSON Web Token",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
-        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
-        "is_verified": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
-        "hashed_secret": "572e8b04aee9650eca28a78c86f5c55544ecec8e",
-        "is_verified": false
+        "hashed_secret": "c7afca0a43fdf3de5be87d84aad6a6f2cdb90e95",
+        "is_verified": false,
+        "line_number": 71
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
         "hashed_secret": "8d149df752cb3dfd41a730fe1a84a1f1edb2844b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 75
       },
       {
         "type": "JSON Web Token",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
         "hashed_secret": "9c66de0d8eec4a5d8bba12bacd35da737796857b",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 77
       },
       {
-        "type": "JSON Web Token",
+        "type": "Secret Keyword",
         "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
-        "hashed_secret": "c7afca0a43fdf3de5be87d84aad6a6f2cdb90e95",
-        "is_verified": false
+        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/fraudcheck/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/TokenRequestServiceTest.java",
+        "hashed_secret": "572e8b04aee9650eca28a78c86f5c55544ecec8e",
+        "is_verified": false,
+        "line_number": 91
       }
     ],
     "lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java": [
@@ -245,48 +269,56 @@
         "type": "Base64 High Entropy String",
         "filename": "lambdas/fraudcheck/src/testFixtures/java/uk/gov/di/ipv/cri/fraud/api/util/TestDataCreator.java",
         "hashed_secret": "5471d5e4e91d0c0d87249d5873d7fcb5a141a582",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 146
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/pact/IssueCredentialHandlerTest.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/pact/IssueCredentialHandlerTest.java",
-        "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
-        "is_verified": false
+        "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
+        "is_verified": false,
+        "line_number": 157
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/pact/IssueCredentialHandlerTest.java",
-        "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
-        "is_verified": false
+        "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
+        "is_verified": false,
+        "line_number": 158
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java": [
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 14
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 16
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java",
         "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
-        "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/fraud/api/service/fixtures/TestFixtures.java",
-        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
-        "is_verified": false
+        "is_verified": false,
+        "line_number": 16
       }
     ]
-  }
+  },
+  "generated_at": "2024-10-04T12:04:50Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -58,6 +58,10 @@ Parameters:
     Description: "Mock TXMA SQS Queue"
     Type: String
     Default: "false"
+  LogGroupRetentionInDays:
+    Description: "Retention for all log groups"
+    Type: Number
+    Default: "30"
 
 Conditions:
   IsDeployedFromPipeline: !Equals
@@ -403,7 +407,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicFraudApi}-public-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   PublicFraudApiAccessLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -417,7 +421,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateFraudApi}-private-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   PrivateFraudApiAccessLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -517,7 +521,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${IdentityCheckingFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   IdentityCheckingFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -599,7 +603,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   IssueCredentialFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Ensure log groups are all set to 30 days retention

### Why did it change

To ensure log groups do not have extended retention lengths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1169](https://govukverify.atlassian.net/browse/LIME-1169)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1169]: https://govukverify.atlassian.net/browse/LIME-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ